### PR TITLE
Implemented discovery endpoint returning the catalog of enabled RWA pairs

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -44,6 +44,10 @@ tags:
       been enabled (see [ADR-0014](https://github.com/0xVoronov/mavryk-external-data/blob/main/docs/adr/0014-rwa-backfill-via-orderbook-order.md)).
       `/ohlcv` shares the same 501 stub as `charts-ft` until volume
       ingestion lands.
+  - name: discovery
+    description: |
+      Catalog endpoints for clients that need to know which entities are
+      available before querying the data endpoints.
 
 paths:
   /healthz:
@@ -576,6 +580,32 @@ paths:
         "409": { $ref: "#/components/responses/Conflict" }
         "500": { $ref: "#/components/responses/Internal" }
 
+  /v1/pairs/rwa:
+    get:
+      tags: [discovery]
+      summary: Catalog of enabled RWA pairs
+      description: |
+        Returns the list of enabled RWA pairs currently served by the API.
+        Use it to discover which `{base}-{quote}` symbols can be passed to
+        `/v1/rwa/{symbol}` and its sibling endpoints — clients construct
+        the symbol as `${base}-${quote}` (both already lowercase).
+
+        Order is stable: `(source, base, quote)` ascending. Disabled pairs
+        are never returned. Empty database returns `[]` (200), not 404.
+      operationId: listRWAPairs
+      responses:
+        "200":
+          description: Array of pair catalog entries.
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/RWAPairCatalogEntry" }
+              example:
+                - { base: mars1, quote: usdt, source: equiteez }
+                - { base: tst,   quote: usdt, source: equiteez }
+        "500": { $ref: "#/components/responses/Internal" }
+
 components:
   parameters:
     Token:
@@ -822,6 +852,26 @@ components:
           Converted price for a target currency from `?in=`.
           Key is the lowercase ISO-4217 code (`usd`, `eur`, `aed`, …).
           Rounded to 6 decimal places.
+
+    RWAPairCatalogEntry:
+      type: object
+      description: |
+        One enabled RWA pair, in the minimal shape needed to build a
+        `/v1/rwa/{symbol}` request. `symbol` is `${base}-${quote}`.
+      required: [base, quote, source]
+      properties:
+        base:
+          type: string
+          description: Lowercase base asset ticker (`rwa_pairs.base_symbol`).
+          example: mars1
+        quote:
+          type: string
+          description: Lowercase quote currency ticker (`rwa_pairs.quote_symbol`).
+          example: usdt
+        source:
+          type: string
+          description: Upstream provider code (matches `sources.code`).
+          example: equiteez
 
     Snapshot:
       type: object

--- a/internal/core/api/http/app.go
+++ b/internal/core/api/http/app.go
@@ -163,6 +163,9 @@ func NewApp(deps AppDeps) *App {
 		RWASource:       prices.SourceEquiteez,
 		MaxInCurrencies: cfg.Server.MaxInCurrencies,
 	}
+	rwaPairsDeps := handlers.RWAPairsDeps{
+		Lookup: deps.Lookup,
+	}
 	SetupRoutes(router, RouterDeps{
 		DB:            deps.DB,
 		ReadinessGate: gate,
@@ -170,6 +173,7 @@ func NewApp(deps AppDeps) *App {
 		TokenCharts:   tokenChartsDeps,
 		RWAPrice:      rwaDeps,
 		RWACharts:     rwaChartsDeps,
+		RWAPairs:      rwaPairsDeps,
 		Change:        changeDeps,
 	})
 

--- a/internal/core/api/http/handlers/rwa_pairs.go
+++ b/internal/core/api/http/handlers/rwa_pairs.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"context"
+	"strings"
+
+	"quotes/internal/core/api/http/common"
+	"quotes/internal/core/domain/prices"
+	"quotes/internal/core/infrastructure/storage/repositories"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RWAPairsLister is the read-only contract the discovery handler needs:
+// every enabled `(base, quote, source)` triple, in a stable order. Kept
+// separate from PairLookup so RWAPriceDeps stays narrow.
+type RWAPairsLister interface {
+	EnabledRWAPairs(ctx context.Context) ([]prices.RWAPair, error)
+}
+
+// RWAPairsDeps wires the discovery endpoint.
+type RWAPairsDeps struct {
+	Lookup RWAPairsLister
+}
+
+// rwaPairDTO is the on-wire shape of one catalog entry. Lowercased fields
+// keep the contract self-consistent with `/v1/rwa/:symbol` parsing
+// (parseRWASymbol lowercases on the way in).
+type rwaPairDTO struct {
+	Base   string `json:"base"`
+	Quote  string `json:"quote"`
+	Source string `json:"source"`
+}
+
+// List — GET /v1/pairs/rwa
+//
+// Returns the catalog of enabled RWA pairs. Clients use it to discover
+// which `{base}-{quote}` symbols to request from `/v1/rwa/:symbol/latest`.
+// Empty database returns `[]`, not 404.
+func (d RWAPairsDeps) List() gin.HandlerFunc {
+	type request struct{}
+	bind := func(_ *gin.Context) (request, error) {
+		return request{}, nil
+	}
+	action := func(ctx context.Context, _ request) ([]rwaPairDTO, error) {
+		pairs, err := d.Lookup.EnabledRWAPairs(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]rwaPairDTO, 0, len(pairs))
+		for _, p := range pairs {
+			out = append(out, rwaPairDTO{
+				Base:   strings.ToLower(p.BaseSymbol),
+				Quote:  strings.ToLower(p.QuoteSymbol),
+				Source: string(p.Source),
+			})
+		}
+		return out, nil
+	}
+	return common.Wrap(bind, action)
+}
+
+// Compile-time sanity: real *repositories.LookupRepository satisfies RWAPairsLister.
+var _ RWAPairsLister = (*repositories.LookupRepository)(nil)

--- a/internal/core/api/http/handlers/rwa_pairs_test.go
+++ b/internal/core/api/http/handlers/rwa_pairs_test.go
@@ -1,0 +1,160 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"quotes/internal/core/domain/prices"
+
+	"github.com/gin-gonic/gin"
+)
+
+// stubPairsLister satisfies handlers.RWAPairsLister. Returns the configured
+// pairs (assumed already enabled + sorted, mirroring the repository contract).
+type stubPairsLister struct {
+	pairs []prices.RWAPair
+	err   error
+	calls int
+}
+
+func (s *stubPairsLister) EnabledRWAPairs(_ context.Context) ([]prices.RWAPair, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.pairs, nil
+}
+
+func newRWAPairsEngine(_ *testing.T, deps RWAPairsDeps) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/v1/pairs/rwa", deps.List())
+	return r
+}
+
+// TestRWAPairs_Shape — happy path: response is an array of
+// {base, quote, source} objects, all keys lowercase, no extra fields,
+// order preserved from the repository.
+func TestRWAPairs_Shape(t *testing.T) {
+	lister := &stubPairsLister{
+		pairs: []prices.RWAPair{
+			{Source: prices.SourceEquiteez, BaseSymbol: "MARS1", QuoteSymbol: "USDT", Enabled: true},
+			{Source: prices.SourceEquiteez, BaseSymbol: "TST", QuoteSymbol: "USDT", Enabled: true},
+		},
+	}
+	deps := RWAPairsDeps{Lookup: lister}
+	r := newRWAPairsEngine(t, deps)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/pairs/rwa", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	if lister.calls != 1 {
+		t.Errorf("lister.calls = %d, want 1", lister.calls)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("decode: %v\n%s", err, w.Body.String())
+	}
+	if len(rows) != 2 {
+		t.Fatalf("len = %d, want 2", len(rows))
+	}
+	for i, row := range rows {
+		if len(row) != 3 {
+			t.Errorf("row[%d] has %d keys, want exactly 3: %v", i, len(row), row)
+		}
+		for _, k := range []string{"base", "quote", "source"} {
+			v, ok := row[k].(string)
+			if !ok {
+				t.Errorf("row[%d].%s is %T, want string", i, k, row[k])
+				continue
+			}
+			if v == "" {
+				t.Errorf("row[%d].%s is empty", i, k)
+			}
+		}
+	}
+	// Lowercased: BaseSymbol "MARS1" → "mars1".
+	if rows[0]["base"] != "mars1" {
+		t.Errorf("rows[0].base = %v, want mars1 (lowercased)", rows[0]["base"])
+	}
+	if rows[0]["quote"] != "usdt" {
+		t.Errorf("rows[0].quote = %v, want usdt (lowercased)", rows[0]["quote"])
+	}
+	if rows[0]["source"] != "equiteez" {
+		t.Errorf("rows[0].source = %v, want equiteez", rows[0]["source"])
+	}
+}
+
+// TestRWAPairs_OrderPreserved — handler does not re-sort; it trusts the
+// repository's ORDER BY. Verifies the wire order matches the input order.
+func TestRWAPairs_OrderPreserved(t *testing.T) {
+	lister := &stubPairsLister{
+		pairs: []prices.RWAPair{
+			{Source: prices.SourceEquiteez, BaseSymbol: "mars1", QuoteSymbol: "usdt", Enabled: true},
+			{Source: prices.SourceEquiteez, BaseSymbol: "tst", QuoteSymbol: "eur", Enabled: true},
+			{Source: prices.SourceEquiteez, BaseSymbol: "tst", QuoteSymbol: "usdt", Enabled: true},
+		},
+	}
+	deps := RWAPairsDeps{Lookup: lister}
+	r := newRWAPairsEngine(t, deps)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/pairs/rwa", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := []struct{ base, quote string }{
+		{"mars1", "usdt"},
+		{"tst", "eur"},
+		{"tst", "usdt"},
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("len = %d, want %d", len(rows), len(want))
+	}
+	for i, w := range want {
+		if rows[i]["base"] != w.base || rows[i]["quote"] != w.quote {
+			t.Errorf("rows[%d] = (%v,%v), want (%s,%s)",
+				i, rows[i]["base"], rows[i]["quote"], w.base, w.quote)
+		}
+	}
+}
+
+// TestRWAPairs_EmptyResult_200 — no pairs in DB → [] (200), not 404.
+func TestRWAPairs_EmptyResult_200(t *testing.T) {
+	deps := RWAPairsDeps{Lookup: &stubPairsLister{}}
+	r := newRWAPairsEngine(t, deps)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/pairs/rwa", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	if body != "[]" && body != "[]\n" {
+		t.Errorf("body = %q, want []", body)
+	}
+}
+
+// TestRWAPairs_RepoError_500 — repository failure propagates as 500
+// via the standard Wrap error mapping.
+func TestRWAPairs_RepoError_500(t *testing.T) {
+	deps := RWAPairsDeps{Lookup: &stubPairsLister{err: errors.New("db down")}}
+	r := newRWAPairsEngine(t, deps)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/pairs/rwa", nil))
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}

--- a/internal/core/api/http/router.go
+++ b/internal/core/api/http/router.go
@@ -15,6 +15,7 @@ type RouterDeps struct {
 	TokenCharts   handlers.TokenChartDeps
 	RWAPrice      handlers.RWAPriceDeps
 	RWACharts     handlers.RWAChartDeps
+	RWAPairs      handlers.RWAPairsDeps
 	Change        handlers.ChangeDeps
 }
 
@@ -40,6 +41,7 @@ type RouterDeps struct {
 //	/v1/rwa/:symbol/series    — line chart (see ADR-0015)
 //	/v1/rwa/:symbol/ohlc      — OHLC candles
 //	/v1/rwa/:symbol/ohlcv     — 501 stub until volume ingestion lands
+//	/v1/pairs/rwa             — enabled RWA pair catalog (discovery)
 func SetupRoutes(engine *gin.Engine, deps RouterDeps) {
 	engine.GET("/healthz", handlers.Liveness())
 	engine.GET("/readyz", handlers.Readiness(deps.DB, deps.ReadinessGate))
@@ -74,6 +76,12 @@ func SetupRoutes(engine *gin.Engine, deps RouterDeps) {
 			rwa.GET("/:symbol/series", deps.RWACharts.Series())
 			rwa.GET("/:symbol/ohlc", deps.RWACharts.OHLC())
 			rwa.GET("/:symbol/ohlcv", handlers.NotImplementedOHLCV())
+		}
+		// Discovery group. Lives outside /v1/rwa because gin's radix
+		// tree won't accept a static segment next to /rwa/:symbol.
+		pairs := v1.Group("/pairs")
+		{
+			pairs.GET("/rwa", deps.RWAPairs.List())
 		}
 	}
 }

--- a/internal/core/infrastructure/storage/repositories/lookup_repository.go
+++ b/internal/core/infrastructure/storage/repositories/lookup_repository.go
@@ -60,6 +60,26 @@ func (r *LookupRepository) RWAPairs(ctx context.Context) ([]prices.RWAPair, erro
 	return out, nil
 }
 
+// EnabledRWAPairs returns enabled rows from `rwa_pairs` sorted by
+// (source_code, base_symbol, quote_symbol). Backs the `/v1/pairs/rwa`
+// discovery endpoint — stable order matters for clients that diff the
+// catalog between polls.
+func (r *LookupRepository) EnabledRWAPairs(ctx context.Context) ([]prices.RWAPair, error) {
+	var rows []entities.RWAPairEntity
+	err := r.db.WithContext(ctx).
+		Where("enabled = ?", true).
+		Order("source_code, base_symbol, quote_symbol").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("load enabled rwa_pairs: %w", err)
+	}
+	out := make([]prices.RWAPair, 0, len(rows))
+	for _, e := range rows {
+		out = append(out, entityToRWAPair(e))
+	}
+	return out, nil
+}
+
 // LookupRWAPair returns one pair by ID, or ErrPairNotFound.
 func (r *LookupRepository) LookupRWAPair(ctx context.Context, id int64) (prices.RWAPair, error) {
 	var e entities.RWAPairEntity


### PR DESCRIPTION
Adds `GET /v1/pairs/rwa` - discovery endpoint returning the catalog of enabled RWA pairs so clients can learn which `{base}-{quote}` symbols to query against `/v1/rwa/:symbol/*`.

Response shape: `[{ base, quote, source }]`, all lowercase, sorted by `(source, base, quote)`, enabled-only, `[]` on empty.

## Changes

- `LookupRepository.EnabledRWAPairs(ctx)` - new repo method with SQL-side filter + stable ORDER BY.
- `handlers/rwa_pairs.go` - new handler + narrow `RWAPairsLister` interface (keeps `PairLookup` minimal).
- Route registered under a new `/v1/pairs` group (sibling to `/v1/rwa/*` because gin's radix tree rejects a static segment next to `:symbol`).
- OpenAPI: new path, `RWAPairCatalogEntry` schema, `discovery` tag.