### PR TITLE
Restore legacy GET /quotes (drop-in for v0.1.0 clients)

### DIFF
--- a/internal/core/api/http/app.go
+++ b/internal/core/api/http/app.go
@@ -166,6 +166,16 @@ func NewApp(deps AppDeps) *App {
 	rwaPairsDeps := handlers.RWAPairsDeps{
 		Lookup: deps.Lookup,
 	}
+	// Legacy /quotes — restored for downstream services that still pin to
+	// the v0.1.0 wide-format route. MVRK + CoinGecko only by design;
+	// hard-coded rather than registry-looked-up so a missing tokens row
+	// doesn't break server startup.
+	legacyQuotesDeps := handlers.LegacyQuotesDeps{
+		Repo:        repositories.NewLegacyQuoteRepository(deps.DB),
+		TokenSymbol: "mvrk",
+		SourceCode:  string(prices.SourceCoinGecko),
+		MaxLimit:    cfg.Server.MaxQueryLimit,
+	}
 	SetupRoutes(router, RouterDeps{
 		DB:            deps.DB,
 		ReadinessGate: gate,
@@ -175,6 +185,7 @@ func NewApp(deps AppDeps) *App {
 		RWACharts:     rwaChartsDeps,
 		RWAPairs:      rwaPairsDeps,
 		Change:        changeDeps,
+		LegacyQuotes:  legacyQuotesDeps,
 	})
 
 	server := &http.Server{

--- a/internal/core/api/http/handlers/legacy_quotes.go
+++ b/internal/core/api/http/handlers/legacy_quotes.go
@@ -1,0 +1,151 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"quotes/internal/core/infrastructure/storage/repositories"
+
+	"github.com/gin-gonic/gin"
+)
+
+// LegacyQuoteFetcher abstracts the wide-pivot store so handler tests don't
+// need a live DB.
+type LegacyQuoteFetcher interface {
+	QueryWide(
+		ctx context.Context,
+		tokenSymbol string,
+		sourceCode string,
+		from time.Time,
+		to time.Time,
+		limit int,
+	) ([]repositories.LegacyQuoteRow, error)
+}
+
+// LegacyQuotesDeps wires the legacy `/quotes` handler. Token + source are
+// fixed to MVRK + CoinGecko (v0.1.0 behaviour); other tokens/sources route
+// through the v1 endpoints.
+type LegacyQuotesDeps struct {
+	Repo        LegacyQuoteFetcher
+	TokenSymbol string // "mvrk"
+	SourceCode  string // "coingecko"
+	MaxLimit    int    // server.max_query_limit
+}
+
+// legacyQuoteOut mirrors the v0.1.0 wire shape exactly: lowercase currency
+// keys, JSON numbers (no quoting), UTC RFC3339 timestamp. Anchors a snapshot
+// contract for clients that still depend on the legacy route.
+type legacyQuoteOut struct {
+	Timestamp string  `json:"timestamp"`
+	BTC       float64 `json:"btc"`
+	USD       float64 `json:"usd"`
+	EUR       float64 `json:"eur"`
+	CNY       float64 `json:"cny"`
+	JPY       float64 `json:"jpy"`
+	KRW       float64 `json:"krw"`
+	ETH       float64 `json:"eth"`
+	GBP       float64 `json:"gbp"`
+}
+
+// LegacyQuotes — GET /quotes
+//
+// Drop-in restoration of the v0.1.0 endpoint. MVRK quotes from CoinGecko, in
+// wide format (one row per timestamp, 8 currency columns). Error envelope
+// matches the legacy shape (`{"error": "..."}`) so older clients keep parsing
+// failures without changes.
+//
+// Query params:
+//   - from  RFC3339, default now-24h
+//   - to    RFC3339, default now
+//   - limit positive int, capped by server.max_query_limit
+func (d LegacyQuotesDeps) LegacyQuotes() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		fromStr := c.Query("from")
+		toStr := c.Query("to")
+		limitStr := c.Query("limit")
+
+		now := time.Now()
+		from := now.Add(-24 * time.Hour)
+		to := now
+
+		if fromStr != "" {
+			t, err := time.Parse(time.RFC3339, fromStr)
+			if err != nil {
+				legacyError(c, http.StatusBadRequest,
+					"Invalid 'from' parameter format. Use RFC3339 format (e.g., 2023-01-01T00:00:00Z)")
+				return
+			}
+			from = t
+		}
+		if toStr != "" {
+			t, err := time.Parse(time.RFC3339, toStr)
+			if err != nil {
+				legacyError(c, http.StatusBadRequest,
+					"Invalid 'to' parameter format. Use RFC3339 format (e.g., 2023-01-01T00:00:00Z)")
+				return
+			}
+			to = t
+		}
+		if from.After(to) {
+			legacyError(c, http.StatusBadRequest,
+				"Invalid time range: 'from' must be before 'to'")
+			return
+		}
+
+		limit := 0
+		if limitStr != "" {
+			parsed, err := strconv.Atoi(limitStr)
+			if err != nil || parsed <= 0 {
+				legacyError(c, http.StatusBadRequest,
+					"Invalid 'limit' parameter. Must be a positive integer")
+				return
+			}
+			if d.MaxLimit > 0 && parsed > d.MaxLimit {
+				legacyError(c, http.StatusBadRequest,
+					"Invalid 'limit' parameter: exceeds maximum")
+				return
+			}
+			limit = parsed
+		}
+
+		rows, err := d.Repo.QueryWide(c.Request.Context(), d.TokenSymbol, d.SourceCode, from, to, limit)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error":   "Failed to get quotes",
+				"details": err.Error(),
+			})
+			return
+		}
+
+		out := make([]legacyQuoteOut, len(rows))
+		for i, r := range rows {
+			out[i] = legacyQuoteOut{
+				Timestamp: r.Timestamp.UTC().Format("2006-01-02T15:04:05Z"),
+				BTC:       r.BTC,
+				USD:       r.USD,
+				EUR:       r.EUR,
+				CNY:       r.CNY,
+				JPY:       r.JPY,
+				KRW:       r.KRW,
+				ETH:       r.ETH,
+				GBP:       r.GBP,
+			}
+		}
+
+		// Use json.Marshal directly so a zero-length slice serialises as `[]`,
+		// matching the legacy wire contract regardless of gin's defaults.
+		body, err := json.Marshal(out)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to encode response"})
+			return
+		}
+		c.Data(http.StatusOK, "application/json; charset=utf-8", body)
+	}
+}
+
+func legacyError(c *gin.Context, status int, msg string) {
+	c.JSON(status, gin.H{"error": msg})
+}

--- a/internal/core/api/http/handlers/legacy_quotes_test.go
+++ b/internal/core/api/http/handlers/legacy_quotes_test.go
@@ -1,0 +1,179 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"quotes/internal/core/infrastructure/storage/repositories"
+
+	"github.com/gin-gonic/gin"
+)
+
+type stubLegacyRepo struct {
+	rows  []repositories.LegacyQuoteRow
+	err   error
+	gotTk string
+	gotSr string
+	gotFr time.Time
+	gotTo time.Time
+	gotLm int
+}
+
+func (s *stubLegacyRepo) QueryWide(
+	_ context.Context, token, source string, from, to time.Time, limit int,
+) ([]repositories.LegacyQuoteRow, error) {
+	s.gotTk, s.gotSr, s.gotFr, s.gotTo, s.gotLm = token, source, from, to, limit
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.rows, nil
+}
+
+func newLegacyEngine(repo LegacyQuoteFetcher) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	deps := LegacyQuotesDeps{
+		Repo:        repo,
+		TokenSymbol: "mvrk",
+		SourceCode:  "coingecko",
+		MaxLimit:    10000,
+	}
+	r.GET("/quotes", deps.LegacyQuotes())
+	return r
+}
+
+func TestLegacyQuotes_WideShape(t *testing.T) {
+	ts := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	repo := &stubLegacyRepo{
+		rows: []repositories.LegacyQuoteRow{
+			{Timestamp: ts, BTC: 6.1e-7, USD: 0.071541, EUR: 0.060941, GBP: 0.053079},
+		},
+	}
+	r := newLegacyEngine(repo)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/quotes?from=2026-04-27T00:00:00Z&to=2026-04-27T23:59:59Z&limit=100", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var got []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, w.Body.String())
+	}
+	if len(got) != 1 {
+		t.Fatalf("rows = %d, want 1", len(got))
+	}
+	row := got[0]
+	wantKeys := []string{"timestamp", "btc", "usd", "eur", "cny", "jpy", "krw", "eth", "gbp"}
+	for _, k := range wantKeys {
+		if _, ok := row[k]; !ok {
+			t.Errorf("missing key %q in row: %v", k, row)
+		}
+	}
+	if row["timestamp"] != "2026-04-27T12:00:00Z" {
+		t.Errorf("timestamp = %v, want RFC3339-Z", row["timestamp"])
+	}
+	if row["usd"].(float64) != 0.071541 {
+		t.Errorf("usd = %v, want 0.071541", row["usd"])
+	}
+	// Missing currencies decode as zero, matching legacy behaviour.
+	if row["cny"].(float64) != 0 {
+		t.Errorf("cny = %v, want 0 (legacy zero-fill)", row["cny"])
+	}
+	if repo.gotTk != "mvrk" || repo.gotSr != "coingecko" {
+		t.Errorf("repo got (%q,%q), want (mvrk,coingecko)", repo.gotTk, repo.gotSr)
+	}
+	if repo.gotLm != 100 {
+		t.Errorf("repo limit = %d, want 100", repo.gotLm)
+	}
+}
+
+func TestLegacyQuotes_DefaultWindowIs24h(t *testing.T) {
+	repo := &stubLegacyRepo{rows: nil}
+	r := newLegacyEngine(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/quotes", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if w.Body.String() != "[]" {
+		t.Errorf("empty body = %q, want []", w.Body.String())
+	}
+	delta := repo.gotTo.Sub(repo.gotFr)
+	if delta < 23*time.Hour || delta > 25*time.Hour {
+		t.Errorf("default window = %v, want ~24h", delta)
+	}
+}
+
+func TestLegacyQuotes_BadFrom_400(t *testing.T) {
+	r := newLegacyEngine(&stubLegacyRepo{})
+	req := httptest.NewRequest(http.MethodGet, "/quotes?from=not-rfc3339", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	var body map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if _, ok := body["error"]; !ok {
+		t.Errorf("legacy error envelope missing 'error' key: %v", body)
+	}
+}
+
+func TestLegacyQuotes_FromAfterTo_400(t *testing.T) {
+	r := newLegacyEngine(&stubLegacyRepo{})
+	req := httptest.NewRequest(http.MethodGet,
+		"/quotes?from=2026-04-27T12:00:00Z&to=2026-04-27T00:00:00Z", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestLegacyQuotes_LimitExceedsMax_400(t *testing.T) {
+	r := newLegacyEngine(&stubLegacyRepo{})
+	req := httptest.NewRequest(http.MethodGet, "/quotes?limit=999999", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestLegacyQuotes_NegativeLimit_400(t *testing.T) {
+	r := newLegacyEngine(&stubLegacyRepo{})
+	req := httptest.NewRequest(http.MethodGet, "/quotes?limit=-1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestLegacyQuotes_RepoError_500WithLegacyEnvelope(t *testing.T) {
+	r := newLegacyEngine(&stubLegacyRepo{err: errors.New("db down")})
+	req := httptest.NewRequest(http.MethodGet, "/quotes", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+	var body map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if _, ok := body["error"]; !ok {
+		t.Errorf("legacy 500 envelope missing 'error' key: %v", body)
+	}
+}

--- a/internal/core/api/http/router.go
+++ b/internal/core/api/http/router.go
@@ -17,6 +17,7 @@ type RouterDeps struct {
 	RWACharts     handlers.RWAChartDeps
 	RWAPairs      handlers.RWAPairsDeps
 	Change        handlers.ChangeDeps
+	LegacyQuotes  handlers.LegacyQuotesDeps
 }
 
 // SetupRoutes registers all routes on the given engine.
@@ -28,6 +29,7 @@ type RouterDeps struct {
 //	/metrics                 — Prometheus
 //	/openapi.yaml            — embedded OpenAPI 3.0 spec
 //	/docs                    — Swagger UI loading /openapi.yaml
+//	/quotes                  — legacy v0.1.0 wide-format MVRK quotes
 //	/v1/prices/:token         — list (range or latest)
 //	/v1/prices/:token/latest  — transposed snapshot
 //	/v1/prices/:token/count   — total row count
@@ -45,6 +47,10 @@ type RouterDeps struct {
 func SetupRoutes(engine *gin.Engine, deps RouterDeps) {
 	engine.GET("/healthz", handlers.Liveness())
 	engine.GET("/readyz", handlers.Readiness(deps.DB, deps.ReadinessGate))
+
+	// Legacy v0.1.0 wide-format MVRK quotes. Kept alive outside /v1 for
+	// downstream services that still call the old route.
+	engine.GET("/quotes", deps.LegacyQuotes.LegacyQuotes())
 
 	// Static OpenAPI 3.0 spec + Swagger UI shell. Both bytes are embedded at
 	// compile time via docs.OpenAPIYAML / docs.SwaggerUIHTML.

--- a/internal/core/infrastructure/storage/repositories/legacy_quotes_repository.go
+++ b/internal/core/infrastructure/storage/repositories/legacy_quotes_repository.go
@@ -1,0 +1,82 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// LegacyQuoteRepository serves the wide-format `/quotes` endpoint preserved
+// from v0.1.0. One DB roundtrip pivots the long-format token_prices rows for
+// one (token, source) into one row per timestamp with eight currency columns.
+type LegacyQuoteRepository struct {
+	db *gorm.DB
+}
+
+func NewLegacyQuoteRepository(db *gorm.DB) *LegacyQuoteRepository {
+	return &LegacyQuoteRepository{db: db}
+}
+
+// LegacyQuoteRow is one pivoted row. Missing currencies at a given ts decode
+// as zero — matching v0.1.0 wire behaviour, which serialised float64 zero
+// rather than omitting the key.
+type LegacyQuoteRow struct {
+	Timestamp time.Time `gorm:"column:ts"`
+	BTC       float64   `gorm:"column:btc"`
+	USD       float64   `gorm:"column:usd"`
+	EUR       float64   `gorm:"column:eur"`
+	CNY       float64   `gorm:"column:cny"`
+	JPY       float64   `gorm:"column:jpy"`
+	KRW       float64   `gorm:"column:krw"`
+	ETH       float64   `gorm:"column:eth"`
+	GBP       float64   `gorm:"column:gbp"`
+}
+
+// QueryWide returns wide-format rows for (token, source) within [from, to],
+// sorted ascending by ts, capped at limit. limit <= 0 means no cap (relies on
+// the caller having already validated against server.max_query_limit).
+//
+// The PK index (token_symbol, source_code, quote_currency, ts) combined with
+// TimescaleDB chunk exclusion on ts keeps this O(window). FILTER aggregation
+// collapses the 8 long rows per ts into one wide row inside Postgres — no
+// pivot work in Go.
+func (r *LegacyQuoteRepository) QueryWide(
+	ctx context.Context,
+	tokenSymbol string,
+	sourceCode string,
+	from time.Time,
+	to time.Time,
+	limit int,
+) ([]LegacyQuoteRow, error) {
+	const sql = `
+SELECT
+  ts,
+  COALESCE((MAX(price) FILTER (WHERE quote_currency = 'btc'))::float8, 0) AS btc,
+  COALESCE((MAX(price) FILTER (WHERE quote_currency = 'usd'))::float8, 0) AS usd,
+  COALESCE((MAX(price) FILTER (WHERE quote_currency = 'eur'))::float8, 0) AS eur,
+  COALESCE((MAX(price) FILTER (WHERE quote_currency = 'cny'))::float8, 0) AS cny,
+  COALESCE((MAX(price) FILTER (WHERE quote_currency = 'jpy'))::float8, 0) AS jpy,
+  COALESCE((MAX(price) FILTER (WHERE quote_currency = 'krw'))::float8, 0) AS krw,
+  COALESCE((MAX(price) FILTER (WHERE quote_currency = 'eth'))::float8, 0) AS eth,
+  COALESCE((MAX(price) FILTER (WHERE quote_currency = 'gbp'))::float8, 0) AS gbp
+FROM token_prices
+WHERE token_symbol = ? AND source_code = ?
+  AND ts >= ? AND ts <= ?
+GROUP BY ts
+ORDER BY ts ASC
+`
+	query := sql
+	args := []any{tokenSymbol, sourceCode, from.UTC(), to.UTC()}
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+
+	var rows []LegacyQuoteRow
+	if err := r.db.WithContext(ctx).Raw(query, args...).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("legacy /quotes pivot: %w", err)
+	}
+	return rows, nil
+}


### PR DESCRIPTION
## Summary
- Bring back `GET /quotes` outside `/v1` for downstream services still pinned to the v0.1.0 wire format.
- Wide-format MVRK rows pivoted server-side in one SQL via FILTER aggregation over `token_prices` — fast path on the PK index + Timescale chunk exclusion.
- Legacy error envelope (`{"error": "..."}`) and zero-fill for missing currencies preserved so existing parsers don't need changes.

## Contract
- `GET /quotes?from=&to=&limit=` — RFC3339 window (default last 24h), `limit` capped by `server.max_query_limit` (10000).
- Response: `[{timestamp, btc, usd, eur, cny, jpy, krw, eth, gbp}, ...]`, sorted `ts ASC`. Empty result is `[]`, not 404.
- MVRK + CoinGecko hard-coded (matches v0.1.0); other tokens stay on `/v1/prices/:token`.
