### PR TITLE
Split public/internal listeners + MBIO JWT on RWA routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 # Server
 # =====================================================================
 SERVER_PORT=3010
+# Second HTTP listener for intra-cluster traffic. RWA routes are open here
+# (no MBIO JWT) and /metrics, /docs, /openapi.yaml are mounted only on this
+# listener when set. Leave unset for the legacy single-port layout.
+# SERVER_INTERNAL_PORT=3011
 SERVER_HOST=0.0.0.0
 # debug | release | test (empty = derive from host)
 # SERVER_GIN_MODE=release
@@ -114,3 +118,30 @@ BACKFILL_BACKOFF_INITIAL_MS=2000
 BACKFILL_BACKOFF_MAX_MS=60000
 # Hard 24h cap on computed backoff so a stuck token doesn't stretch waits to weeks.
 BACKFILL_MAX_BACKOFF_MS=86400000
+
+# =====================================================================
+# Auth (MBIO JWT)
+# =====================================================================
+# Verifies RS256 Bearer tokens on the public listener's RWA routes
+# (/v1/rwa/*, /v1/pairs/rwa). Internal listener traffic skips this entirely.
+#
+# AUTH_ENABLED=false disables the middleware (dev/CI only). When unset/true the
+# service refuses to start without AUTH_MBIO_JWT_ISSUER + a JWKS host (or local PEM).
+# AUTH_ENABLED=true
+# JWKS host: JWKS is fetched from {base}/.well-known/jwks.json. Either of these
+# must be set in production unless AUTH_JWT_LOCAL_VERIFY_PUBLIC_KEY is used.
+# AUTH_MBIO_JWT_BASE_URL=
+# AUTH_MBIO_API_GATEWAY_BASE_URL=
+# Required when auth is enabled — exact `iss` claim the IdP mints. MBIO uses a
+# plain string (e.g. "mbio-api-gateway"), not a URL.
+# AUTH_MBIO_JWT_ISSUER=mbio-api-gateway
+# Optional — pins `aud` if MBIO ever starts minting it. Leave empty otherwise;
+# the middleware logs a startup warning so the disabled check stays visible.
+# AUTH_MBIO_JWT_AUDIENCE=
+# How long keyfunc holds the JWKS before refresh. Default 5m.
+# AUTH_JWKS_CACHE_TTL=5m
+# Local / e2e fast-path: standard base64 of an RSA public-key PEM. When set the
+# middleware skips JWKS entirely and verifies signatures against this key.
+# Generate with `openssl genrsa -out private.pem 2048 && openssl rsa -in private.pem
+#   -pubout -out public.pem && base64 -i public.pem`.
+# AUTH_JWT_LOCAL_VERIFY_PUBLIC_KEY=

--- a/cmd/quotes/main.go
+++ b/cmd/quotes/main.go
@@ -106,7 +106,7 @@ func run() int {
 		prices.SourceCoinGecko,
 	)
 
-	httpApp := httpapp.NewApp(httpapp.AppDeps{
+	httpApp, err := httpapp.NewApp(httpapp.AppDeps{
 		Config:          cfg,
 		DB:              db.DB,
 		Logger:          logger,
@@ -119,6 +119,10 @@ func run() int {
 		FXConverter:     fxConverter,
 		Lookup:          lookup,
 	})
+	if err != nil {
+		logger.Error().Err(err).Msg("http_app_init_failed")
+		return 1
+	}
 
 	liveJob := jobs.NewCoinGeckoLiveJob(cfg, tokenAppRepo, logger)
 	backfillJob := jobs.NewCoinGeckoBackfillJob(cfg, tokenAppRepo, tokenRepo, stateRepo, logger)
@@ -194,7 +198,7 @@ func run() int {
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer shutdownCancel()
-	if err := httpApp.Server().Shutdown(shutdownCtx); err != nil {
+	if err := httpApp.Shutdown(shutdownCtx); err != nil {
 		logger.Error().Err(err).Msg("http_shutdown_error")
 	} else {
 		logger.Info().Msg("http_shutdown_complete")

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,11 @@
 server:
   port: "3010"
+  # internal_port: second HTTP listener for intra-cluster callers. RWA routes
+  # are open here (no MBIO JWT) and /metrics, /docs, /openapi.yaml move here.
+  # Empty (the local default) = single-port mode — everything on `port`.
+  # In k8s the helm chart sets SERVER_INTERNAL_PORT=3011 via env, splitting
+  # the listeners. Uncomment locally only if you want to mirror that split.
+  # internal_port: "3011"
   host: "0.0.0.0"
   # gin_mode: debug | release | test. Empty → derive from host (localhost → debug).
   # gin_mode: "release"
@@ -101,6 +107,25 @@ rwa:
   enabled: false
   interval_seconds: 60
   concurrency: 4
+
+# MBIO JWT verification for the public listener's RWA routes (/v1/rwa/*,
+# /v1/pairs/rwa). Internal listener traffic skips this entirely.
+#
+# - enabled: false here is a local-dev convenience. Production must keep it on
+#   (omit / true). The flag does not affect the internal listener.
+# - mbio_jwt_issuer: required when enabled. MBIO uses the plain string
+#   "mbio-api-gateway", not a URL.
+# - mbio_jwt_audience: optional. MBIO does not currently mint `aud`, so leaving
+#   this empty is the correct default. A startup warn-log fires when empty.
+# - jwt_local_verify_public_key: base64-PEM of an RSA public key for local /
+#   CI verification. When set the middleware skips the JWKS fetch entirely.
+auth:
+  enabled: false
+  mbio_jwt_base_url: ""
+  mbio_jwt_issuer: "mbio-api-gateway"
+  mbio_jwt_audience: ""
+  jwks_cache_ttl: "5m"
+  jwt_local_verify_public_key: ""
 
 # Per-token live/backfill overrides.
 tokens:

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module quotes
 go 1.25.0
 
 require (
+	github.com/MicahParks/keyfunc/v3 v3.8.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/gin-gonic/gin v1.11.0
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.5.4
 	github.com/joho/godotenv v1.4.0
@@ -25,6 +27,7 @@ require (
 require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
+	github.com/MicahParks/jwkset v0.11.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOhoyQ=
+github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
+github.com/MicahParks/keyfunc/v3 v3.8.0 h1:Hx2dgIjAXGk9slakM6rV9BOeaWDPEXXZ4Us8guNBfds=
+github.com/MicahParks/keyfunc/v3 v3.8.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -76,6 +80,8 @@ github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PU
 github.com/goccy/go-yaml v1.19.1 h1:3rG3+v8pkhRqoQ/88NYNMHYVGYztCOCIZ7UQhu7H+NE=
 github.com/goccy/go-yaml v1.19.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -1,0 +1,64 @@
+package config
+
+import "time"
+
+// AuthConfig holds MBIO API Gateway JWT verification settings (RS256 via JWKS).
+// The service never issues tokens; it only verifies Bearer tokens from the gateway.
+//
+// Verification is mounted on the **public** HTTP listener for RWA-scoped routes
+// (/v1/rwa/* and /v1/pairs/rwa). The **internal** listener never wraps these
+// routes in auth — intra-cluster callers reach them without a token.
+//
+// Local / e2e: set JWTLocalVerifyPublicKeyBase64 (base64 of PEM) + MBIOJWTIssuer
+// to verify RS256 JWTs signed with the matching private key, skipping JWKS fetch.
+type AuthConfig struct {
+	// Enabled controls whether the MBIO JWT middleware is constructed at all.
+	// Nil = default on (verify). When *false the public listener still serves
+	// the RWA routes but without any auth wrapper — used in local dev and tests
+	// where issuing real JWTs is too much friction.
+	Enabled *bool `yaml:"enabled"`
+
+	// MBIOAPIGatewayBaseURL — API Gateway base URL. Used as a fallback when
+	// MBIOJWTBaseURL is unset (some deployments serve JWKS from the same host
+	// that fronts the API).
+	MBIOAPIGatewayBaseURL string `yaml:"mbio_api_gateway_base_url"`
+
+	// MBIOJWTBaseURL — JWT / JWKS host base; JWKS is loaded from
+	// {base}/.well-known/jwks.json. Takes precedence over MBIOAPIGatewayBaseURL.
+	MBIOJWTBaseURL string `yaml:"mbio_jwt_base_url"`
+
+	// MBIOJWTIssuer — expected `iss` claim; passed to jwt.WithIssuer. Required
+	// when JWT verification is enabled.
+	MBIOJWTIssuer string `yaml:"mbio_jwt_issuer"`
+
+	// MBIOJWTAudience — expected `aud` claim; passed to jwt.WithAudience.
+	// Required in this service (unlike rwa-backend, which warns and continues
+	// when unset). Without it any MBIO-issued token for a sibling service would
+	// be accepted on RWA data — see Validate.
+	MBIOJWTAudience string `yaml:"mbio_jwt_audience"`
+
+	// JWKSCacheTTL — how long the keyfunc cache holds JWKS before refresh
+	// (default 5m).
+	JWKSCacheTTL time.Duration `yaml:"jwks_cache_ttl"`
+
+	// JWTLocalVerifyPublicKeyBase64 — standard base64 of an RSA public-key PEM,
+	// for local-only RS256 verification without a JWKS endpoint. When non-empty
+	// it short-circuits the JWKS path entirely (useful for tests and offline
+	// docker-compose runs).
+	JWTLocalVerifyPublicKeyBase64 string `yaml:"jwt_local_verify_public_key"`
+}
+
+// JWTVerificationEnabled reports whether the MBIO JWT middleware should be built.
+// Default true; explicit `auth.enabled: false` (or AUTH_ENABLED=false) disables it.
+func (a *AuthConfig) JWTVerificationEnabled() bool {
+	if a == nil || a.Enabled == nil {
+		return true
+	}
+	return *a.Enabled
+}
+
+func defaultAuthConfig() AuthConfig {
+	return AuthConfig{
+		JWKSCacheTTL: 5 * time.Minute,
+	}
+}

--- a/internal/config/auth_local_keys.go
+++ b/internal/config/auth_local_keys.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+// LocalJWTVerifyConfigured reports whether local RSA public-key verification is
+// selected — when true, the middleware skips the JWKS fetch entirely and uses
+// the embedded key for signature checks. Intended for local dev and CI.
+func (a *AuthConfig) LocalJWTVerifyConfigured() bool {
+	if a == nil {
+		return false
+	}
+	return strings.TrimSpace(a.JWTLocalVerifyPublicKeyBase64) != ""
+}
+
+// LocalJWTVerifyPublicKeyPEMBytes decodes JWTLocalVerifyPublicKeyBase64
+// (standard base64 of a PEM-encoded RSA public key) and returns PEM bytes.
+// Empty config returns (nil, nil).
+func (a *AuthConfig) LocalJWTVerifyPublicKeyPEMBytes() ([]byte, error) {
+	if a == nil {
+		return nil, nil
+	}
+	b64 := strings.TrimSpace(strings.ReplaceAll(a.JWTLocalVerifyPublicKeyBase64, "\n", ""))
+	if b64 == "" {
+		return nil, nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, fmt.Errorf("jwt_local_verify_public_key base64: %w", err)
+	}
+	return []byte(strings.TrimSpace(string(raw))), nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,5 +10,6 @@ type Config struct {
 	Equiteez  EquiteezConfig         `yaml:"equiteez"`
 	Backfill  BackfillConfig         `yaml:"backfill"`
 	RWA       RWAConfig              `yaml:"rwa"`
+	Auth      AuthConfig             `yaml:"auth"`
 	Tokens    map[string]TokenConfig `yaml:"tokens"`
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -131,6 +131,10 @@ func setDefaults(config *Config) {
 		config.Equiteez.Backfill.MaxBackoffMs = 24 * 60 * 60 * 1000
 	}
 
+	if config.Auth.JWKSCacheTTL == 0 {
+		config.Auth.JWKSCacheTTL = defaultAuthConfig().JWKSCacheTTL
+	}
+
 	if config.RWA.IntervalSeconds == 0 && config.RWA.Enabled {
 		// 10s matches Mavryk block time — orderbook prices on Equiteez change
 		// at most once per block, so polling faster doesn't surface fresher

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -13,6 +13,9 @@ func overrideWithEnv(config *Config) error {
 	if port := os.Getenv("SERVER_PORT"); port != "" {
 		config.Server.Port = port
 	}
+	if port := os.Getenv("SERVER_INTERNAL_PORT"); port != "" {
+		config.Server.InternalPort = port
+	}
 	if host := os.Getenv("SERVER_HOST"); host != "" {
 		config.Server.Host = host
 	}
@@ -286,6 +289,36 @@ func overrideWithEnv(config *Config) error {
 			return fmt.Errorf("RWA_CONCURRENCY: invalid int %q: %w", v, err)
 		}
 		config.RWA.Concurrency = val
+	}
+
+	if v := os.Getenv("AUTH_ENABLED"); v != "" {
+		val, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("AUTH_ENABLED: invalid bool %q: %w", v, err)
+		}
+		config.Auth.Enabled = &val
+	}
+	if v := os.Getenv("AUTH_MBIO_API_GATEWAY_BASE_URL"); v != "" {
+		config.Auth.MBIOAPIGatewayBaseURL = v
+	}
+	if v := os.Getenv("AUTH_MBIO_JWT_BASE_URL"); v != "" {
+		config.Auth.MBIOJWTBaseURL = v
+	}
+	if v := os.Getenv("AUTH_MBIO_JWT_ISSUER"); v != "" {
+		config.Auth.MBIOJWTIssuer = v
+	}
+	if v := os.Getenv("AUTH_MBIO_JWT_AUDIENCE"); v != "" {
+		config.Auth.MBIOJWTAudience = v
+	}
+	if v := os.Getenv("AUTH_JWKS_CACHE_TTL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("AUTH_JWKS_CACHE_TTL: invalid duration %q: %w", v, err)
+		}
+		config.Auth.JWKSCacheTTL = d
+	}
+	if v := os.Getenv("AUTH_JWT_LOCAL_VERIFY_PUBLIC_KEY"); v != "" {
+		config.Auth.JWTLocalVerifyPublicKeyBase64 = v
 	}
 	return nil
 }

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -3,7 +3,13 @@ package config
 // ServerConfig holds HTTP server bind options and response-cache settings.
 type ServerConfig struct {
 	Port string `yaml:"port"`
-	Host string `yaml:"host"`
+	// InternalPort, when non-empty, binds a second HTTP listener for intra-cluster
+	// traffic. The internal listener mounts the same routes as the public one but
+	// **without** the MBIO JWT middleware on /v1/rwa/* and /v1/pairs/rwa, and
+	// hosts /metrics. Reach it via a ClusterIP Service + NetworkPolicy. Empty
+	// disables the second listener (single-port mode, useful for local dev).
+	InternalPort string `yaml:"internal_port"`
+	Host         string `yaml:"host"`
 	// GinMode: debug, release, or test. Empty means derive from host (localhost/127.0.0.1 → debug).
 	GinMode string `yaml:"gin_mode"`
 	// HTTP server timeouts (see net/http.Server). YAML uses Go duration strings, e.g. "30s".

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -27,6 +27,7 @@ func (c *Config) Validate() error {
 		c.validateEquiteezBackfill,
 		c.validateTokens,
 		c.validateRWA,
+		c.validateAuth,
 		c.validateProductionSafety,
 	} {
 		if err := fn(); err != nil {
@@ -45,6 +46,15 @@ func (c *Config) validateServer() error {
 	}
 	if port, err := strconv.Atoi(strings.TrimSpace(c.Server.Port)); err != nil || port < 1 || port > 65535 {
 		return fmt.Errorf("server.port must be a TCP port number 1-65535, got %q", c.Server.Port)
+	}
+	if ip := strings.TrimSpace(c.Server.InternalPort); ip != "" {
+		port, err := strconv.Atoi(ip)
+		if err != nil || port < 1 || port > 65535 {
+			return fmt.Errorf("server.internal_port must be a TCP port number 1-65535, got %q", c.Server.InternalPort)
+		}
+		if ip == strings.TrimSpace(c.Server.Port) {
+			return fmt.Errorf("server.internal_port (%q) must differ from server.port", ip)
+		}
 	}
 	if c.Server.LatestQuoteCacheTTLSeconds < 0 {
 		return fmt.Errorf("server.latest_quote_cache_ttl_seconds must be >= 0, got %d", c.Server.LatestQuoteCacheTTLSeconds)
@@ -230,6 +240,42 @@ func (c *Config) validateRWA() error {
 	}
 	if c.RWA.Enabled && strings.TrimSpace(c.Equiteez.IndexerURL) == "" {
 		return fmt.Errorf("rwa.enabled=true requires equiteez.indexer_url to be set")
+	}
+	return nil
+}
+
+// validateAuth checks the MBIO JWT settings when verification is enabled.
+// Verification is on by default; explicit `auth.enabled: false` disables all checks.
+//
+// Matches rwa-backend's posture: audience is **optional**. MBIO currently mints
+// tokens with only iss/sub/exp/iat (no aud), so enforcing aud would reject every
+// real token. The middleware emits a one-shot startup warn-log when aud is empty
+// so the missing check stays visible in ops logs.
+func (c *Config) validateAuth() error {
+	a := &c.Auth
+	if !a.JWTVerificationEnabled() {
+		return nil
+	}
+	if strings.TrimSpace(a.MBIOJWTIssuer) == "" {
+		return fmt.Errorf("auth.mbio_jwt_issuer is required when auth is enabled (env AUTH_MBIO_JWT_ISSUER)")
+	}
+	if a.JWKSCacheTTL < 0 {
+		return fmt.Errorf("auth.jwks_cache_ttl must be >= 0, got %s", a.JWKSCacheTTL)
+	}
+	if a.LocalJWTVerifyConfigured() {
+		pemBytes, err := a.LocalJWTVerifyPublicKeyPEMBytes()
+		if err != nil {
+			return err
+		}
+		if len(pemBytes) == 0 {
+			return fmt.Errorf("auth.jwt_local_verify_public_key is empty after base64 decode (AUTH_JWT_LOCAL_VERIFY_PUBLIC_KEY)")
+		}
+		// Deeper PEM validity (ParseRSAPublicKeyFromPEM) happens at middleware
+		// build time — keeps validate.go free of the JWT dep.
+		return nil
+	}
+	if strings.TrimSpace(a.MBIOJWTBaseURL) == "" && strings.TrimSpace(a.MBIOAPIGatewayBaseURL) == "" {
+		return fmt.Errorf("auth.mbio_jwt_base_url or auth.mbio_api_gateway_base_url is required when AUTH_JWT_LOCAL_VERIFY_PUBLIC_KEY is unset; set one of AUTH_MBIO_JWT_BASE_URL / AUTH_MBIO_API_GATEWAY_BASE_URL, or provide a base64 PEM in AUTH_JWT_LOCAL_VERIFY_PUBLIC_KEY for local RS256 verification")
 	}
 	return nil
 }

--- a/internal/core/api/http/app.go
+++ b/internal/core/api/http/app.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog"
+	"golang.org/x/sync/errgroup"
 	"gorm.io/gorm"
 )
 
@@ -38,16 +40,28 @@ type AppDeps struct {
 	Lookup      *repositories.LookupRepository
 }
 
+// App owns one or two HTTP servers:
+//
+//	publicServer   — :{server.port}, internet-facing. CORS + rate-limit on,
+//	                 MBIO JWT middleware guards /v1/rwa/* and /v1/pairs/rwa.
+//	internalServer — :{server.internal_port}, optional. No CORS, no rate-limit,
+//	                 no RWA auth. Hosts /metrics. Reached only from inside the
+//	                 cluster via a ClusterIP Service + NetworkPolicy.
+//
+// When server.internal_port is unset (local dev) internalServer is nil and
+// /metrics is mounted on the public engine — the single-port legacy layout.
 type App struct {
-	config        *config.Config
-	server        *http.Server
-	logger        *zerolog.Logger
-	readinessGate *handlers.ReadinessGate
+	config         *config.Config
+	publicServer   *http.Server
+	internalServer *http.Server
+	logger         *zerolog.Logger
+	readinessGate  *handlers.ReadinessGate
 }
 
-// NewApp builds the HTTP server. Side-effects: sets gin mode from config, creates
-// the engine, registers middleware, mounts routes, configures timeouts.
-func NewApp(deps AppDeps) *App {
+// NewApp builds the HTTP server(s). Side-effects: sets gin mode from config,
+// creates engines, registers middleware, mounts routes, configures timeouts,
+// builds the MBIO JWT middleware (when auth is enabled).
+func NewApp(deps AppDeps) (*App, error) {
 	logger := deps.Logger
 	if logger == nil {
 		nop := zerolog.Nop()
@@ -55,6 +69,78 @@ func NewApp(deps AppDeps) *App {
 	}
 	cfg := deps.Config
 
+	configureGinMode(cfg)
+
+	appLogger := logging.WithComponent(logger, "http_app")
+	gate := handlers.NewReadinessGate()
+	routerDepsBase := buildRouterDeps(deps, cfg, gate)
+
+	// MBIO JWT middleware. Built once, mounted only on the public engine. When
+	// auth is disabled (auth.enabled=false, dev/CI only) the public listener
+	// serves RWA routes without a token wrapper — same as the internal one.
+	var rwaAuth gin.HandlerFunc
+	if cfg.Auth.JWTVerificationEnabled() {
+		mid, err := httpmw.MBIOJWT(&cfg.Auth, appLogger)
+		if err != nil {
+			return nil, err
+		}
+		rwaAuth = mid
+	} else {
+		appLogger.Warn().Msg("auth_disabled_rwa_routes_open_on_public_listener")
+	}
+
+	publicEngine := buildPublicEngine(cfg, appLogger)
+	publicDeps := routerDepsBase
+	publicDeps.RWAAuth = rwaAuth
+	// Docs (Swagger UI + openapi.yaml) get mounted on the internal listener
+	// when one exists; here on the public engine only as a fallback for
+	// single-port local-dev runs.
+	publicDeps.MountDocs = strings.TrimSpace(cfg.Server.InternalPort) == ""
+	SetupRoutes(publicEngine, publicDeps)
+
+	publicServer := &http.Server{
+		Addr:              cfg.Server.Host + ":" + cfg.Server.Port,
+		Handler:           publicEngine,
+		ReadHeaderTimeout: cfg.Server.ReadHeaderTimeout.D(),
+		ReadTimeout:       cfg.Server.ReadTimeout.D(),
+		WriteTimeout:      cfg.Server.WriteTimeout.D(),
+		IdleTimeout:       cfg.Server.IdleTimeout.D(),
+	}
+
+	app := &App{
+		config:        cfg,
+		publicServer:  publicServer,
+		logger:        appLogger,
+		readinessGate: gate,
+	}
+
+	internalPort := strings.TrimSpace(cfg.Server.InternalPort)
+	if internalPort == "" {
+		// Single-port mode (local dev). /metrics stays on the public engine for
+		// scrape continuity; the security note in app docs applies.
+		publicEngine.GET("/metrics", gin.WrapH(promhttp.Handler()))
+		return app, nil
+	}
+
+	internalEngine := buildInternalEngine(cfg, appLogger)
+	internalDeps := routerDepsBase
+	internalDeps.RWAAuth = nil
+	internalDeps.MountDocs = true
+	SetupRoutes(internalEngine, internalDeps)
+	internalEngine.GET("/metrics", gin.WrapH(promhttp.Handler()))
+
+	app.internalServer = &http.Server{
+		Addr:              cfg.Server.Host + ":" + internalPort,
+		Handler:           internalEngine,
+		ReadHeaderTimeout: cfg.Server.ReadHeaderTimeout.D(),
+		ReadTimeout:       cfg.Server.ReadTimeout.D(),
+		WriteTimeout:      cfg.Server.WriteTimeout.D(),
+		IdleTimeout:       cfg.Server.IdleTimeout.D(),
+	}
+	return app, nil
+}
+
+func configureGinMode(cfg *config.Config) {
 	switch strings.ToLower(strings.TrimSpace(cfg.Server.GinMode)) {
 	case "debug":
 		gin.SetMode(gin.DebugMode)
@@ -72,12 +158,14 @@ func NewApp(deps AppDeps) *App {
 	default:
 		gin.SetMode(gin.ReleaseMode)
 	}
+}
 
-	appLogger := logging.WithComponent(logger, "http_app")
-
+// buildPublicEngine returns the engine used for the external-facing listener:
+// full middleware stack, CORS allowlist, optional inbound rate limit.
+func buildPublicEngine(cfg *config.Config, logger *zerolog.Logger) *gin.Engine {
 	router := gin.New()
 	router.Use(logging.RequestIDMiddleware(""))
-	router.Use(logging.RequestLogger(appLogger))
+	router.Use(logging.RequestLogger(logger))
 	router.Use(httpmw.PrometheusHTTP())
 	router.Use(gin.Recovery())
 	router.Use(httpmw.CORS(cfg.Server.CORS))
@@ -88,11 +176,27 @@ func NewApp(deps AppDeps) *App {
 	if cfg.Server.PprofEnabled {
 		httpmw.RegisterPprof(router)
 	}
+	return router
+}
 
-	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+// buildInternalEngine returns the engine used for the intra-cluster listener.
+// CORS and rate-limit are stripped: callers are trusted pods inside the cluster,
+// not browsers or external clients. Logging, prometheus, recovery and per-handler
+// timeout stay — they protect against runaway internal callers and keep metrics
+// consistent.
+func buildInternalEngine(cfg *config.Config, logger *zerolog.Logger) *gin.Engine {
+	router := gin.New()
+	router.Use(logging.RequestIDMiddleware(""))
+	router.Use(logging.RequestLogger(logger))
+	router.Use(httpmw.PrometheusHTTP())
+	router.Use(gin.Recovery())
+	if to := cfg.Server.HandlerTimeout.D(); to > 0 {
+		router.Use(httpmw.HandlerTimeout(to))
+	}
+	return router
+}
 
-	gate := handlers.NewReadinessGate()
-
+func buildRouterDeps(deps AppDeps, cfg *config.Config, gate *handlers.ReadinessGate) RouterDeps {
 	tokenDeps := handlers.TokenPriceDeps{
 		Service:       deps.TokenPriceQuery,
 		Repo:          deps.TokenPriceRepo,
@@ -163,9 +267,7 @@ func NewApp(deps AppDeps) *App {
 		RWASource:       prices.SourceEquiteez,
 		MaxInCurrencies: cfg.Server.MaxInCurrencies,
 	}
-	rwaPairsDeps := handlers.RWAPairsDeps{
-		Lookup: deps.Lookup,
-	}
+	rwaPairsDeps := handlers.RWAPairsDeps{Lookup: deps.Lookup}
 	// Legacy /quotes — restored for downstream services that still pin to
 	// the v0.1.0 wide-format route. MVRK + CoinGecko only by design;
 	// hard-coded rather than registry-looked-up so a missing tokens row
@@ -176,7 +278,7 @@ func NewApp(deps AppDeps) *App {
 		SourceCode:  string(prices.SourceCoinGecko),
 		MaxLimit:    cfg.Server.MaxQueryLimit,
 	}
-	SetupRoutes(router, RouterDeps{
+	return RouterDeps{
 		DB:            deps.DB,
 		ReadinessGate: gate,
 		TokenPrice:    tokenDeps,
@@ -186,30 +288,46 @@ func NewApp(deps AppDeps) *App {
 		RWAPairs:      rwaPairsDeps,
 		Change:        changeDeps,
 		LegacyQuotes:  legacyQuotesDeps,
-	})
-
-	server := &http.Server{
-		Addr:              cfg.Server.Host + ":" + cfg.Server.Port,
-		Handler:           router,
-		ReadHeaderTimeout: cfg.Server.ReadHeaderTimeout.D(),
-		ReadTimeout:       cfg.Server.ReadTimeout.D(),
-		WriteTimeout:      cfg.Server.WriteTimeout.D(),
-		IdleTimeout:       cfg.Server.IdleTimeout.D(),
 	}
-
-	return &App{config: cfg, server: server, logger: appLogger, readinessGate: gate}
 }
 
+// Run starts both listeners (or just the public one in single-port mode) and
+// blocks until either returns. The first error from either server cancels the
+// errgroup so the caller's Shutdown can drain both cleanly.
 func (a *App) Run() error {
-	a.logger.Info().Str("addr", a.server.Addr).Msg("starting_http_server")
-	return a.server.ListenAndServe()
+	g, _ := errgroup.WithContext(context.Background())
+	g.Go(func() error {
+		a.logger.Info().Str("addr", a.publicServer.Addr).Str("listener", "public").Msg("starting_http_server")
+		if err := a.publicServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	})
+	if a.internalServer != nil {
+		g.Go(func() error {
+			a.logger.Info().Str("addr", a.internalServer.Addr).Str("listener", "internal").Msg("starting_http_server")
+			if err := a.internalServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				return err
+			}
+			return nil
+		})
+	}
+	return g.Wait()
 }
 
-// Server returns the underlying HTTP server for graceful shutdown.
-func (a *App) Server() *http.Server { return a.server }
+// Shutdown gracefully stops both listeners in parallel. ctx is shared so a single
+// deadline applies to the whole drain — typical caller passes 30s.
+func (a *App) Shutdown(ctx context.Context) error {
+	g, _ := errgroup.WithContext(ctx)
+	g.Go(func() error { return a.publicServer.Shutdown(ctx) })
+	if a.internalServer != nil {
+		g.Go(func() error { return a.internalServer.Shutdown(ctx) })
+	}
+	return g.Wait()
+}
 
 // StartDraining flips /readyz to 503 so a load balancer pulls the pod out of
-// rotation before Server.Shutdown stops accepting connections. Idempotent.
+// rotation before Shutdown stops accepting connections. Idempotent.
 func (a *App) StartDraining() {
 	if a.readinessGate != nil {
 		a.readinessGate.StartDraining()

--- a/internal/core/api/http/common/errors.go
+++ b/internal/core/api/http/common/errors.go
@@ -21,6 +21,10 @@ func HTTPStatus(code coreerrors.Code) int {
 	switch code {
 	case coreerrors.CodeInvalidArgument:
 		return http.StatusBadRequest
+	case coreerrors.CodeUnauthorized:
+		return http.StatusUnauthorized
+	case coreerrors.CodeForbidden:
+		return http.StatusForbidden
 	case coreerrors.CodeNotFound:
 		return http.StatusNotFound
 	case coreerrors.CodeConflict:

--- a/internal/core/api/http/middleware/mbio_jwt.go
+++ b/internal/core/api/http/middleware/mbio_jwt.go
@@ -1,0 +1,190 @@
+package middleware
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"quotes/internal/config"
+	httpCommon "quotes/internal/core/api/http/common"
+	coreerrors "quotes/internal/core/common/errors"
+
+	"github.com/MicahParks/keyfunc/v3"
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/rs/zerolog"
+)
+
+// MBIOJWT builds a Gin middleware that verifies RS256 Bearer JWTs issued by the
+// MBIO Identity Provider and forwarded by the MBIO API Gateway.
+//
+// Verification path:
+//   - JWKS over HTTP (default): keyfunc fetches and caches {base}/.well-known/jwks.json
+//     with refresh interval = cfg.JWKSCacheTTL.
+//   - Local RSA public key (when cfg.LocalJWTVerifyConfigured is true): the key
+//     is read from cfg.JWTLocalVerifyPublicKeyBase64 (base64 of PEM) — used for
+//     local dev / CI where contacting the real MBIO is impractical.
+//
+// Claim checks: iss (mandatory), exp/nbf (jwt/v5 default), sub (must be present).
+// Audience is enforced only when cfg.MBIOJWTAudience is set; MBIO currently mints
+// tokens without `aud`, so the default is "no aud check". A startup warn-log
+// fires once when aud is empty so the missing check stays visible in ops logs.
+//
+// On any failure the middleware writes a JSON error envelope via httpCommon.RespondError
+// and aborts the gin chain. No fallthrough — the wrapped handler never runs.
+func MBIOJWT(cfg *config.AuthConfig, logger *zerolog.Logger) (gin.HandlerFunc, error) {
+	log := logger.With().Str("component", "mbio_jwt").Logger()
+
+	parserOpts := []jwt.ParserOption{
+		jwt.WithValidMethods([]string{"RS256"}),
+		jwt.WithIssuer(cfg.MBIOJWTIssuer),
+	}
+	if aud := strings.TrimSpace(cfg.MBIOJWTAudience); aud != "" {
+		parserOpts = append(parserOpts, jwt.WithAudience(aud))
+		log.Debug().Str("aud", aud).Msg("jwt_audience_check_enabled")
+	} else {
+		log.Warn().Msg("jwt_audience_check_disabled_set_AUTH_MBIO_JWT_AUDIENCE_to_enforce_aud")
+	}
+
+	keyFunc, err := buildKeyFunc(cfg, &log)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(c *gin.Context) {
+		tokenString, err := extractBearer(c.GetHeader("Authorization"))
+		if err != nil {
+			httpCommon.RespondError(c, err)
+			c.Abort()
+			return
+		}
+		if err := requireJWTHeaderTyp(tokenString); err != nil {
+			httpCommon.RespondError(c, coreerrors.InvalidArgument(err.Error()))
+			c.Abort()
+			return
+		}
+
+		// We only consume RegisteredClaims (RFC 7519). The token's `sub` is the
+		// MBIO Gateway service identity; this middleware's whole job is to
+		// verify signature + issuer + audience + expiry. Per-user authorization
+		// is not performed here (this service serves cross-tenant market data).
+		var claims jwt.RegisteredClaims
+		token, err := jwt.ParseWithClaims(tokenString, &claims, keyFunc, parserOpts...)
+		if err != nil {
+			respondJWTErr(c, err, &log)
+			c.Abort()
+			return
+		}
+		if !token.Valid {
+			httpCommon.RespondError(c, coreerrors.Unauthorized("Invalid token"))
+			c.Abort()
+			return
+		}
+		if strings.TrimSpace(claims.Subject) == "" {
+			httpCommon.RespondError(c, coreerrors.Forbidden("JWT missing subject"))
+			c.Abort()
+			return
+		}
+		c.Next()
+	}, nil
+}
+
+func buildKeyFunc(cfg *config.AuthConfig, log *zerolog.Logger) (jwt.Keyfunc, error) {
+	if cfg.LocalJWTVerifyConfigured() {
+		pemBytes, err := cfg.LocalJWTVerifyPublicKeyPEMBytes()
+		if err != nil {
+			return nil, err
+		}
+		pub, err := jwt.ParseRSAPublicKeyFromPEM(pemBytes)
+		if err != nil {
+			return nil, fmt.Errorf("local jwt verify public key: %w", err)
+		}
+		log.Debug().Msg("jwt_verify_mode=local_rsa_public_key")
+		return func(t *jwt.Token) (interface{}, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+			}
+			return pub, nil
+		}, nil
+	}
+
+	base := strings.TrimRight(strings.TrimSpace(cfg.MBIOJWTBaseURL), "/")
+	if base == "" {
+		base = strings.TrimRight(strings.TrimSpace(cfg.MBIOAPIGatewayBaseURL), "/")
+	}
+	jwksURL := base + "/.well-known/jwks.json"
+	override := keyfunc.Override{
+		RefreshInterval: cfg.JWKSCacheTTL,
+		HTTPTimeout:     15 * time.Second,
+	}
+	kf, err := keyfunc.NewDefaultOverrideCtx(context.Background(), []string{jwksURL}, override)
+	if err != nil {
+		return nil, fmt.Errorf("jwks init for %s: %w", jwksURL, err)
+	}
+	log.Debug().Str("jwks_url", jwksURL).Msg("jwt_verify_mode=jwks")
+	return kf.Keyfunc, nil
+}
+
+func extractBearer(authHeader string) (string, error) {
+	if authHeader == "" {
+		return "", coreerrors.Unauthorized("Authorization header required")
+	}
+	parts := strings.SplitN(authHeader, " ", 3)
+	if len(parts) != 2 || parts[0] != "Bearer" {
+		return "", coreerrors.Unauthorized("Invalid authorization format. Expected 'Bearer <token>'")
+	}
+	tok := strings.TrimSpace(parts[1])
+	if tok == "" {
+		return "", coreerrors.Unauthorized("Empty bearer token")
+	}
+	return tok, nil
+}
+
+func respondJWTErr(c *gin.Context, err error, log *zerolog.Logger) {
+	switch {
+	case errors.Is(err, jwt.ErrTokenExpired):
+		httpCommon.RespondError(c, coreerrors.Unauthorized("Token expired"))
+	case errors.Is(err, jwt.ErrTokenInvalidIssuer):
+		httpCommon.RespondError(c, coreerrors.Unauthorized("Invalid token issuer"))
+	case errors.Is(err, jwt.ErrTokenInvalidAudience):
+		httpCommon.RespondError(c, coreerrors.Unauthorized("Invalid token audience"))
+	case errors.Is(err, jwt.ErrTokenRequiredClaimMissing):
+		// jwt/v5 raises this when WithAudience is set but `aud` is absent on the token.
+		httpCommon.RespondError(c, coreerrors.Unauthorized("Token missing required claim"))
+	case errors.Is(err, jwt.ErrTokenInvalidClaims):
+		httpCommon.RespondError(c, coreerrors.Forbidden("Invalid JWT claims"))
+	default:
+		log.Debug().Err(err).Msg("jwt_verify_failed")
+		httpCommon.RespondError(c, coreerrors.Unauthorized("Invalid token"))
+	}
+}
+
+type jwtHeader struct {
+	Typ string `json:"typ"`
+}
+
+// requireJWTHeaderTyp rejects tokens whose header `typ` is set to something other
+// than `JWT` (case-insensitive). When `typ` is absent we accept — jwt/v5 already
+// validates the signing algorithm via WithValidMethods.
+func requireJWTHeaderTyp(token string) error {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil
+	}
+	var h jwtHeader
+	if err := json.Unmarshal(raw, &h); err != nil {
+		return nil
+	}
+	if h.Typ != "" && !strings.EqualFold(h.Typ, "JWT") {
+		return fmt.Errorf("jwt header typ must be JWT")
+	}
+	return nil
+}

--- a/internal/core/api/http/middleware/mbio_jwt_test.go
+++ b/internal/core/api/http/middleware/mbio_jwt_test.go
@@ -1,0 +1,214 @@
+package middleware_test
+
+import (
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"quotes/internal/config"
+	httpmw "quotes/internal/core/api/http/middleware"
+	"quotes/internal/testutil"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testIssuer   = "https://mbio.test/issuer"
+	testAudience = "mavryk-external-data"
+	testSubject  = "mbio-api-gateway"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// buildEngineWithLocalKey wires up MBIOJWT with a fresh RSA key pair and a
+// single protected route. Returns the matching private key so tests can mint
+// tokens against it.
+func buildEngineWithLocalKey(t *testing.T) (*gin.Engine, *rsa.PrivateKey) {
+	t.Helper()
+	priv, publicPEM, _, err := testutil.GenerateRSAJWTKeyPair(2048)
+	require.NoError(t, err)
+
+	cfg := &config.AuthConfig{
+		MBIOJWTIssuer:                 testIssuer,
+		MBIOJWTAudience:               testAudience,
+		JWTLocalVerifyPublicKeyBase64: testutil.EncodePublicKeyBase64(publicPEM),
+	}
+	logger := zerolog.Nop()
+	mid, err := httpmw.MBIOJWT(cfg, &logger)
+	require.NoError(t, err)
+
+	r := gin.New()
+	r.GET("/protected", mid, func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+	return r, priv
+}
+
+func performGet(t *testing.T, r http.Handler, header string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	if header != "" {
+		req.Header.Set("Authorization", header)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func parseErrCode(t *testing.T, body []byte) string {
+	t.Helper()
+	var env struct {
+		Code string `json:"code"`
+	}
+	require.NoError(t, json.Unmarshal(body, &env))
+	return env.Code
+}
+
+func TestMBIOJWT_MissingHeader_Returns401(t *testing.T) {
+	r, _ := buildEngineWithLocalKey(t)
+	w := performGet(t, r, "")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.Equal(t, "UNAUTHORIZED", parseErrCode(t, w.Body.Bytes()))
+}
+
+func TestMBIOJWT_NonBearerScheme_Returns401(t *testing.T) {
+	r, _ := buildEngineWithLocalKey(t)
+	w := performGet(t, r, "Basic dXNlcjpwYXNz")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.Equal(t, "UNAUTHORIZED", parseErrCode(t, w.Body.Bytes()))
+}
+
+func TestMBIOJWT_EmptyBearer_Returns401(t *testing.T) {
+	r, _ := buildEngineWithLocalKey(t)
+	w := performGet(t, r, "Bearer ")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMBIOJWT_ValidToken_PassesThrough(t *testing.T) {
+	r, priv := buildEngineWithLocalKey(t)
+	tok, err := testutil.SignLocalJWT(priv, testutil.LocalJWTOpts{
+		Issuer:   testIssuer,
+		Audience: testAudience,
+		Subject:  testSubject,
+		TTL:      5 * time.Minute,
+	})
+	require.NoError(t, err)
+	w := performGet(t, r, "Bearer "+tok)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "ok", w.Body.String())
+}
+
+func TestMBIOJWT_ExpiredToken_Returns401(t *testing.T) {
+	r, priv := buildEngineWithLocalKey(t)
+	tok, err := testutil.SignLocalJWT(priv, testutil.LocalJWTOpts{
+		Issuer:   testIssuer,
+		Audience: testAudience,
+		Subject:  testSubject,
+		IssuedAt: time.Now().UTC().Add(-2 * time.Hour),
+		TTL:      time.Minute, // expired 119 minutes ago
+	})
+	require.NoError(t, err)
+	w := performGet(t, r, "Bearer "+tok)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMBIOJWT_WrongIssuer_Returns401(t *testing.T) {
+	r, priv := buildEngineWithLocalKey(t)
+	tok, err := testutil.SignLocalJWT(priv, testutil.LocalJWTOpts{
+		Issuer:   "https://wrong.example/iss",
+		Audience: testAudience,
+		Subject:  testSubject,
+		TTL:      5 * time.Minute,
+	})
+	require.NoError(t, err)
+	w := performGet(t, r, "Bearer "+tok)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMBIOJWT_WrongAudience_Returns401(t *testing.T) {
+	r, priv := buildEngineWithLocalKey(t)
+	tok, err := testutil.SignLocalJWT(priv, testutil.LocalJWTOpts{
+		Issuer:   testIssuer,
+		Audience: "some-other-service",
+		Subject:  testSubject,
+		TTL:      5 * time.Minute,
+	})
+	require.NoError(t, err)
+	w := performGet(t, r, "Bearer "+tok)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMBIOJWT_NoAudienceConfigured_AcceptsTokenWithoutAud(t *testing.T) {
+	// MBIO mints tokens without `aud`. When AuthConfig.MBIOJWTAudience is empty,
+	// the middleware must skip WithAudience and accept the token. A startup
+	// warn-log fires (covered by inspection, not assertion here).
+	priv, publicPEM, _, err := testutil.GenerateRSAJWTKeyPair(2048)
+	require.NoError(t, err)
+	cfg := &config.AuthConfig{
+		MBIOJWTIssuer: testIssuer,
+		// MBIOJWTAudience intentionally empty.
+		JWTLocalVerifyPublicKeyBase64: testutil.EncodePublicKeyBase64(publicPEM),
+	}
+	logger := zerolog.Nop()
+	mid, err := httpmw.MBIOJWT(cfg, &logger)
+	require.NoError(t, err)
+	r := gin.New()
+	r.GET("/protected", mid, func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+
+	tok, err := testutil.SignLocalJWT(priv, testutil.LocalJWTOpts{
+		Issuer:  testIssuer,
+		Subject: testSubject,
+		TTL:     5 * time.Minute,
+	})
+	require.NoError(t, err)
+	w := performGet(t, r, "Bearer "+tok)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestMBIOJWT_MissingSubject_Returns403(t *testing.T) {
+	r, priv := buildEngineWithLocalKey(t)
+	tok, err := testutil.SignLocalJWT(priv, testutil.LocalJWTOpts{
+		Issuer:   testIssuer,
+		Audience: testAudience,
+		// Subject intentionally empty.
+		TTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+	w := performGet(t, r, "Bearer "+tok)
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.Equal(t, "FORBIDDEN", parseErrCode(t, w.Body.Bytes()))
+}
+
+func TestMBIOJWT_WrongSigningKey_Returns401(t *testing.T) {
+	// Tampering one byte of a base64-encoded signature is unreliable (some flips
+	// still yield a valid byte-string the verifier rejects only stochastically).
+	// Sign with a completely different RSA key instead — that always fails.
+	r, _ := buildEngineWithLocalKey(t)
+	otherPriv, _, _, err := testutil.GenerateRSAJWTKeyPair(2048)
+	require.NoError(t, err)
+	tok, err := testutil.SignLocalJWT(otherPriv, testutil.LocalJWTOpts{
+		Issuer:   testIssuer,
+		Audience: testAudience,
+		Subject:  testSubject,
+		TTL:      5 * time.Minute,
+	})
+	require.NoError(t, err)
+	w := performGet(t, r, "Bearer "+tok)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMBIOJWT_BuildFails_OnInvalidLocalPEM(t *testing.T) {
+	cfg := &config.AuthConfig{
+		MBIOJWTIssuer:                 testIssuer,
+		MBIOJWTAudience:               testAudience,
+		JWTLocalVerifyPublicKeyBase64: "bm90LXBlbQ==", // base64("not-pem")
+	}
+	logger := zerolog.Nop()
+	_, err := httpmw.MBIOJWT(cfg, &logger)
+	require.Error(t, err)
+}

--- a/internal/core/api/http/router.go
+++ b/internal/core/api/http/router.go
@@ -8,6 +8,18 @@ import (
 )
 
 // RouterDeps holds the per-domain handler bundles plus DB and the readiness gate.
+//
+// RWAAuth, when non-nil, wraps /v1/rwa/* and /v1/pairs/rwa in the MBIO JWT
+// middleware. It is non-nil on the public listener and nil on the internal
+// listener — same handler graph, same code path, different exposure surface.
+//
+// MountDocs, when true, registers /openapi.yaml and /docs (Swagger UI). When
+// the two-listener layout is active these are mounted on the internal engine
+// only — the API spec is operator documentation, not customer-facing. In
+// single-port mode (no internal listener) docs go on the public engine so
+// local-dev `curl /docs` still works.
+//
+// See app.go for the wiring.
 type RouterDeps struct {
 	DB            *gorm.DB
 	ReadinessGate *handlers.ReadinessGate
@@ -18,17 +30,19 @@ type RouterDeps struct {
 	RWAPairs      handlers.RWAPairsDeps
 	Change        handlers.ChangeDeps
 	LegacyQuotes  handlers.LegacyQuotesDeps
+	RWAAuth       gin.HandlerFunc
+	MountDocs     bool
 }
 
 // SetupRoutes registers all routes on the given engine.
 //
-// Hierarchy:
+// Hierarchy (public listener; internal mirrors this minus RWA auth):
 //
 //	/healthz                 — liveness
 //	/readyz                  — readiness (db ping + drain gate)
-//	/metrics                 — Prometheus
-//	/openapi.yaml            — embedded OpenAPI 3.0 spec
-//	/docs                    — Swagger UI loading /openapi.yaml
+//	/metrics                 — Prometheus (internal listener only)
+//	/openapi.yaml            — embedded OpenAPI 3.0 spec (internal only when two-port)
+//	/docs                    — Swagger UI (internal only when two-port)
 //	/quotes                  — legacy v0.1.0 wide-format MVRK quotes
 //	/v1/prices/:token         — list (range or latest)
 //	/v1/prices/:token/latest  — transposed snapshot
@@ -53,10 +67,14 @@ func SetupRoutes(engine *gin.Engine, deps RouterDeps) {
 	engine.GET("/quotes", deps.LegacyQuotes.LegacyQuotes())
 
 	// Static OpenAPI 3.0 spec + Swagger UI shell. Both bytes are embedded at
-	// compile time via docs.OpenAPIYAML / docs.SwaggerUIHTML.
-	engine.GET("/openapi.yaml", handlers.OpenAPISpec())
-	engine.GET("/docs", handlers.SwaggerUI())
-	engine.GET("/docs/", handlers.SwaggerUI())
+	// compile time via docs.OpenAPIYAML / docs.SwaggerUIHTML. In two-listener
+	// mode these live on the internal engine only — the public listener does
+	// not expose the API spec.
+	if deps.MountDocs {
+		engine.GET("/openapi.yaml", handlers.OpenAPISpec())
+		engine.GET("/docs", handlers.SwaggerUI())
+		engine.GET("/docs/", handlers.SwaggerUI())
+	}
 
 	v1 := engine.Group("/v1")
 	{
@@ -73,6 +91,9 @@ func SetupRoutes(engine *gin.Engine, deps RouterDeps) {
 			ft.GET("/:token/ohlcv", handlers.NotImplementedOHLCV())
 		}
 		rwa := v1.Group("/rwa")
+		if deps.RWAAuth != nil {
+			rwa.Use(deps.RWAAuth)
+		}
 		{
 			rwa.GET("/:symbol", deps.RWAPrice.ListBySymbol())
 			rwa.GET("/:symbol/latest", deps.RWAPrice.LatestBySymbol())
@@ -84,8 +105,12 @@ func SetupRoutes(engine *gin.Engine, deps RouterDeps) {
 			rwa.GET("/:symbol/ohlcv", handlers.NotImplementedOHLCV())
 		}
 		// Discovery group. Lives outside /v1/rwa because gin's radix
-		// tree won't accept a static segment next to /rwa/:symbol.
+		// tree won't accept a static segment next to /rwa/:symbol. Shares
+		// the RWA auth posture — catalog is treated as RWA data.
 		pairs := v1.Group("/pairs")
+		if deps.RWAAuth != nil {
+			pairs.Use(deps.RWAAuth)
+		}
 		{
 			pairs.GET("/rwa", deps.RWAPairs.List())
 		}

--- a/internal/core/common/errors/errors.go
+++ b/internal/core/common/errors/errors.go
@@ -13,6 +13,8 @@ const (
 	CodeUnavailable         Code = "UNAVAILABLE"
 	CodeRangeNotSatisfiable Code = "RANGE_NOT_SATISFIABLE"
 	CodeNotImplemented      Code = "NOT_IMPLEMENTED"
+	CodeUnauthorized        Code = "UNAUTHORIZED"
+	CodeForbidden           Code = "FORBIDDEN"
 )
 
 // Error is an application error safe to expose to HTTP clients (Message + Code only via responder).
@@ -79,6 +81,21 @@ func NotImplemented(message string) *Error {
 // InvalidArgument so clients can render "narrow your range" UX.
 func RangeNotSatisfiable(message string) *Error {
 	return &Error{Code: CodeRangeNotSatisfiable, Message: message}
+}
+
+// Unauthorized marks a missing or invalid Bearer credential (HTTP 401).
+// Used by the MBIO JWT middleware on /v1/rwa/* and /v1/pairs/rwa for public-listener
+// requests that fail signature/issuer/audience/expiry checks. Internal-listener
+// traffic never sees this — the middleware is only mounted on the public engine.
+func Unauthorized(message string) *Error {
+	return &Error{Code: CodeUnauthorized, Message: message}
+}
+
+// Forbidden marks an authenticated request that lacks the required claim shape
+// (HTTP 403). Distinct from Unauthorized so clients can tell "log in" from
+// "your token is fine but your account can't do this".
+func Forbidden(message string) *Error {
+	return &Error{Code: CodeForbidden, Message: message}
 }
 
 // Wrap builds an error with an explicit code (use when none of the helpers fit).

--- a/internal/testutil/local_jwt.go
+++ b/internal/testutil/local_jwt.go
@@ -1,0 +1,101 @@
+// Package testutil holds shared helpers for unit and integration tests.
+//
+// local_jwt.go provides RSA key generation and RS256 token signing so middleware
+// tests can mint valid Bearer JWTs without contacting a real MBIO Identity
+// Provider. Mirrors the layout used in mavryk-rwa-backend.
+package testutil
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// GenerateRSAJWTKeyPair creates an RSA key pair and returns the private key
+// plus PKIX public PEM and PKCS#1 private PEM. Use bits >= 2048; smaller values
+// are silently bumped to 2048.
+func GenerateRSAJWTKeyPair(bits int) (priv *rsa.PrivateKey, publicPEM []byte, privatePEM []byte, err error) {
+	if bits < 2048 {
+		bits = 2048
+	}
+	priv, err = rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	privDER := x509.MarshalPKCS1PrivateKey(priv)
+	privatePEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: privDER})
+	pubDER, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	publicPEM = pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	return priv, publicPEM, privatePEM, nil
+}
+
+// EncodePublicKeyBase64 wraps a PEM-encoded public key in standard base64,
+// matching the format AuthConfig.JWTLocalVerifyPublicKeyBase64 expects.
+func EncodePublicKeyBase64(publicPEM []byte) string {
+	return base64.StdEncoding.EncodeToString(publicPEM)
+}
+
+// LocalJWTOpts controls non-default token fields. Zero values fall back to a
+// well-formed token with sensible defaults.
+type LocalJWTOpts struct {
+	Issuer    string
+	Audience  string
+	Subject   string
+	TTL       time.Duration
+	NotBefore time.Time     // optional; default = now
+	IssuedAt  time.Time     // optional; default = now
+	ExpiresIn time.Duration // alias for TTL when TTL == 0
+	OmitTyp   bool          // skip the typ=JWT header (test the typ-check path)
+}
+
+// SignLocalJWT builds an RS256 JWT with typ=JWT (unless OmitTyp). Returns the
+// compact serialization (header.payload.signature).
+func SignLocalJWT(priv *rsa.PrivateKey, opts LocalJWTOpts) (string, error) {
+	if priv == nil {
+		return "", fmt.Errorf("private key is nil")
+	}
+	if strings.TrimSpace(opts.Issuer) == "" {
+		return "", fmt.Errorf("issuer is required")
+	}
+	// Subject is intentionally optional: middleware tests need to mint a token
+	// with an empty `sub` to exercise the "JWT missing subject" path.
+	now := time.Now().UTC()
+	iat := opts.IssuedAt
+	if iat.IsZero() {
+		iat = now
+	}
+	ttl := opts.TTL
+	if ttl == 0 {
+		ttl = opts.ExpiresIn
+	}
+	if ttl == 0 {
+		ttl = 5 * time.Minute
+	}
+	claims := jwt.RegisteredClaims{
+		Issuer:    opts.Issuer,
+		Subject:   opts.Subject,
+		IssuedAt:  jwt.NewNumericDate(iat),
+		ExpiresAt: jwt.NewNumericDate(iat.Add(ttl)),
+	}
+	if !opts.NotBefore.IsZero() {
+		claims.NotBefore = jwt.NewNumericDate(opts.NotBefore)
+	}
+	if a := strings.TrimSpace(opts.Audience); a != "" {
+		claims.Audience = jwt.ClaimStrings{a}
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	if !opts.OmitTyp {
+		tok.Header["typ"] = "JWT"
+	}
+	return tok.SignedString(priv)
+}


### PR DESCRIPTION
## Summary

- Second HTTP listener on `SERVER_INTERNAL_PORT` for intra-cluster traffic. Same routes, no MBIO JWT on RWA, `/metrics` + `/docs` + `/openapi.yaml` move here.
- Public listener wraps `/v1/rwa/*` and `/v1/pairs/rwa` in an RS256 JWT middleware (JWKS or local PEM). FT routes (`/v1/prices/*`) stay open.
- `aud` is optional - MBIO mints tokens with only `iss`/`sub`/`exp`/`iat`. Startup warn-log when empty (mirrors `mavryk-rwa-backend`).

## Code (`mavryk-external-data`)

- `internal/config/auth.go` + `auth_local_keys.go` - `AuthConfig` with JWKS/local-PEM modes; validate refuses to start without `mbio_jwt_issuer` when auth is on.
- `internal/core/api/http/middleware/mbio_jwt.go` - gin middleware; maps jwt/v5 errors to 401/403; 10 unit tests via `internal/testutil/local_jwt.go`.
- `internal/core/api/http/{router,app}.go` - single `SetupRoutes` driven by `RWAAuth` (nil on internal, non-nil on public) and `MountDocs`. `NewApp` returns `(*App, error)` and runs both servers via `errgroup`.
- `internal/core/common/errors` - `CodeUnauthorized` / `CodeForbidden` + HTTP mapping.
- `cmd/quotes/main.go` - handles `NewApp` error; `Shutdown(ctx)` drains both servers.

## Helm (`mavryk-infra/helm-charts/mavryk-external-data`)

- `app-deployment.yaml` - second `containerPort: internal`, `AUTH_*` env, `SERVER_INTERNAL_PORT`.
- `app-service.yaml` - second port on the same `ClusterIP` Service.
- `templates/networkpolicy.yaml` - public port open, internal port allowlisted (default: any pod, any namespace; tighten when consumers are known).
- `network.values.yaml` - issuer `mbio-api-gateway`, JWKS host `https://core-api.mb-dev.io/api/rwa/v1` (same as rwa-backend dev), `healthCheck.path` fixed `/api/v1/health` → `/healthz`, `coingecko.baseUrl` moved to top-level so the chart renders without `--set`.

## Consumers

Inside the cluster: `http://mavryk-external-data-app.mavryk-external-data-app.svc.cluster.local:3011` - open RWA, no token required. `mavryk-wallet-backend` hits `/v1/rwa/{symbol}/latest` and must switch to this URL.
