### PR TITLE
Outbound request observability + per-token env overrides

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,41 @@ BACKFILL_BACKOFF_MAX_MS=60000
 BACKFILL_MAX_BACKOFF_MS=86400000
 
 # =====================================================================
+# Per-token overrides
+# =====================================================================
+# Format: TOKEN_<NAME>__<FIELD>     (note the DOUBLE underscore)
+#
+# Names mirror the `tokens:` map in config.yaml (lowercase). Env wins over yaml.
+# A token that doesn't exist in yaml gets Enabled=true by default, so a one-off
+# TOKEN_FOO__INTERVAL_SECONDS=60 lands as a live-enabled token.
+#
+# Supported fields per token:
+#   INTERVAL_SECONDS         live-poll interval (seconds)
+#   ENABLED                  enable/disable live collection (true/false)
+#   TIMEOUT_SECONDS          HTTP timeout for this token's client
+#   MIN_TIME_RANGE_SECONDS   floor on (to - from) for a live tick
+#   LIVE_LOOKBACK_SECONDS    live job window: now - lookback .. now
+#   MAX_CHUNK_MINUTES        upper bound on chunk size
+#   BACKFILL_ENABLED         per-token backfill opt-out (true/false)
+#                            global BACKFILL_ENABLED=false still wins as kill-switch
+#   BACKFILL_START_FROM      RFC3339 or YYYY-MM-DD; floor for the backfill cursor
+#   BACKFILL_CHUNK_MINUTES   reverse-fetch window size in minutes
+
+# --- MVRK ---
+# TOKEN_MVRK__INTERVAL_SECONDS=60
+# TOKEN_MVRK__ENABLED=true
+# TOKEN_MVRK__BACKFILL_ENABLED=true
+# TOKEN_MVRK__BACKFILL_START_FROM=2025-09-18T14:00:00Z
+# TOKEN_MVRK__BACKFILL_CHUNK_MINUTES=360
+
+# --- USDT ---
+# TOKEN_USDT__INTERVAL_SECONDS=240
+# TOKEN_USDT__ENABLED=true
+# TOKEN_USDT__BACKFILL_ENABLED=false
+# TOKEN_USDT__BACKFILL_START_FROM=
+# TOKEN_USDT__BACKFILL_CHUNK_MINUTES=360
+
+# =====================================================================
 # Auth (MBIO JWT)
 # =====================================================================
 # Verifies RS256 Bearer tokens on the public listener's RWA routes

--- a/grafana/dashboards/mavryk-external-data.json
+++ b/grafana/dashboards/mavryk-external-data.json
@@ -24,7 +24,7 @@
       "gridPos": { "h": 4, "w": 24, "x": 0, "y": 0 },
       "options": {
         "mode": "markdown",
-        "content": "**Mavryk External Data** — observability dashboard.\n\nFour metric families in this board:\n- **HTTP (inbound)** — `http_*` from gin middleware.\n- **Outbound HTTP** — `outbound_http_*` from the resilience stack (CoinGecko + Equiteez).\n- **Background jobs** — `job_*` and `backfill_*` from live, backfill, RWA collectors.\n- **Database pool** — `db_pool_*` sampled every 15s by `metrics.StartDBPoolCollector`.\n\nSet **namespace** to your scrape label (default: `mavryk-external-data`)."
+        "content": "**Mavryk External Data** — observability dashboard.\n\nFour metric families in this board:\n- **HTTP (inbound)** — `http_*` from gin middleware.\n- **Outbound HTTP** — `outbound_http_*` from the resilience stack (CoinGecko + Equiteez). `outbound_http_requests_total{component,outcome}` counts every attempt (incl. retries); subtract `outbound_http_retries_total` to get logical-request RPS.\n- **Background jobs** — `job_*` and `backfill_*` from live, backfill, RWA collectors.\n- **Database pool** — `db_pool_*` sampled every 15s by `metrics.StartDBPoolCollector`.\n\nSet **namespace** to your scrape label (default: `mavryk-external-data`)."
       }
     },
 
@@ -139,14 +139,75 @@
         "expr": "histogram_quantile(0.95, sum by (component, le) (rate(outbound_http_rate_limit_wait_seconds_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
         "legendFormat": "{{component}}" }]
     },
+    {
+      "type": "timeseries", "id": 15, "title": "Outbound RPS by component",
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 40 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "description": "Every attempt (including retries) counted once. Subtract outbound_http_retries_total to get logical-request RPS."
+        }
+      },
+      "targets": [{ "refId": "A",
+        "expr": "sum by (component) (rate(outbound_http_requests_total{namespace=\"$namespace\"}[$__rate_interval]))",
+        "legendFormat": "{{component}}" }]
+    },
+    {
+      "type": "timeseries", "id": 16, "title": "Outbound requests by outcome",
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 40 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "description": "Outcome: 2xx healthy, 4xx caller bug / rate-limited, 5xx upstream, error = transport failure (no HTTP status)."
+        }
+      },
+      "targets": [{ "refId": "A",
+        "expr": "sum by (component, outcome) (rate(outbound_http_requests_total{namespace=\"$namespace\"}[$__rate_interval]))",
+        "legendFormat": "{{component}} {{outcome}}" }]
+    },
+    {
+      "type": "stat", "id": 17, "title": "Outbound requests last 1h (by component)",
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 46 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "description": "Total outbound attempts in the last hour. Useful for capacity planning against CoinGecko's quota."
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "targets": [{ "refId": "A",
+        "expr": "sum by (component) (increase(outbound_http_requests_total{namespace=\"$namespace\"}[1h]))",
+        "legendFormat": "{{component}}" }]
+    },
+    {
+      "type": "timeseries", "id": 18, "title": "Outbound error ratio (% non-2xx + transport)",
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 46 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "description": "Share of attempts that returned 4xx/5xx or failed at the transport layer. Sustained > 5% is alertable."
+        }
+      },
+      "targets": [{ "refId": "A",
+        "expr": "sum by (component) (rate(outbound_http_requests_total{namespace=\"$namespace\",outcome!=\"2xx\"}[$__rate_interval])) / clamp_min(sum by (component) (rate(outbound_http_requests_total{namespace=\"$namespace\"}[$__rate_interval])), 1e-9)",
+        "legendFormat": "{{component}}" }]
+    },
 
     { "type": "row", "id": 20, "title": "Background jobs (live / backfill / RWA)",
-      "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 40 }, "panels": [] },
+      "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 52 }, "panels": [] },
 
     {
       "type": "timeseries", "id": 21, "title": "Job tick duration p95 by (job, entity)",
       "datasource": { "type": "prometheus", "uid": "Prometheus" },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 41 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 53 },
       "fieldConfig": { "defaults": { "unit": "s" } },
       "targets": [{ "refId": "A",
         "expr": "histogram_quantile(0.95, sum by (job, source, entity, le) (rate(job_tick_duration_seconds_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
@@ -155,7 +216,7 @@
     {
       "type": "timeseries", "id": 22, "title": "Job errors by reason (rate)",
       "datasource": { "type": "prometheus", "uid": "Prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 49 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 61 },
       "fieldConfig": { "defaults": { "unit": "short" } },
       "targets": [{ "refId": "A",
         "expr": "sum by (job, source, reason) (rate(job_errors_total{namespace=\"$namespace\"}[$__rate_interval]))",
@@ -164,7 +225,7 @@
     {
       "type": "timeseries", "id": 23, "title": "Rows affected (rate)",
       "datasource": { "type": "prometheus", "uid": "Prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 49 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 61 },
       "fieldConfig": { "defaults": { "unit": "short" } },
       "targets": [{ "refId": "A",
         "expr": "sum by (job, source, entity) (rate(job_rows_affected_total{namespace=\"$namespace\"}[$__rate_interval]))",
@@ -172,12 +233,12 @@
     },
 
     { "type": "row", "id": 30, "title": "Backfill cursor",
-      "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 57 }, "panels": [] },
+      "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 69 }, "panels": [] },
 
     {
       "type": "timeseries", "id": 31, "title": "Oldest backfilled timestamp (cursor) per token",
       "datasource": { "type": "prometheus", "uid": "Prometheus" },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 58 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 70 },
       "fieldConfig": {
         "defaults": {
           "unit": "dateTimeAsIso",
@@ -191,7 +252,7 @@
     {
       "type": "timeseries", "id": 32, "title": "Auto-disabled events (rate)",
       "datasource": { "type": "prometheus", "uid": "Prometheus" },
-      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 66 },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 78 },
       "fieldConfig": { "defaults": { "unit": "short" } },
       "targets": [{ "refId": "A",
         "expr": "sum by (entity, reason) (increase(backfill_auto_disabled_total{namespace=\"$namespace\"}[1h]))",
@@ -199,12 +260,12 @@
     },
 
     { "type": "row", "id": 40, "title": "Database connection pool",
-      "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 72 }, "panels": [] },
+      "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 84 }, "panels": [] },
 
     {
       "type": "timeseries", "id": 41, "title": "DB pool connections (open / in_use / idle)",
       "datasource": { "type": "prometheus", "uid": "Prometheus" },
-      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 73 },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 85 },
       "fieldConfig": { "defaults": { "unit": "short" } },
       "targets": [
         { "refId": "A", "expr": "db_pool_open_connections{namespace=\"$namespace\"}",   "legendFormat": "open" },
@@ -215,7 +276,7 @@
     {
       "type": "stat", "id": 42, "title": "Open connections (current)",
       "datasource": { "type": "prometheus", "uid": "Prometheus" },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 73 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 85 },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
@@ -238,7 +299,7 @@
     {
       "type": "timeseries", "id": 43, "title": "DB pool wait duration (cumulative seconds)",
       "datasource": { "type": "prometheus", "uid": "Prometheus" },
-      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 81 },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 93 },
       "fieldConfig": {
         "defaults": {
           "unit": "s",
@@ -251,12 +312,12 @@
     },
 
     { "type": "row", "id": 50, "title": "FX conversions (RWA `?in=`)",
-      "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 87 }, "panels": [] },
+      "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 99 }, "panels": [] },
 
     {
       "type": "timeseries", "id": 51, "title": "FX conversion p95 by (source_token, target)",
       "datasource": { "type": "prometheus", "uid": "Prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 88 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 100 },
       "fieldConfig": {
         "defaults": {
           "unit": "s",
@@ -270,7 +331,7 @@
     {
       "type": "timeseries", "id": 52, "title": "FX conversion outcomes (rate by result)",
       "datasource": { "type": "prometheus", "uid": "Prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 88 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 100 },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
@@ -287,7 +348,7 @@
     {
       "type": "timeseries", "id": 53, "title": "FX stale-rate per target (alertable)",
       "datasource": { "type": "prometheus", "uid": "Prometheus" },
-      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 96 },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 108 },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
@@ -324,6 +385,6 @@
   "timezone": "browser",
   "title": "Mavryk External Data (Quotes)",
   "uid": "mavryk-external-data-quotes",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -320,5 +320,96 @@ func overrideWithEnv(config *Config) error {
 	if v := os.Getenv("AUTH_JWT_LOCAL_VERIFY_PUBLIC_KEY"); v != "" {
 		config.Auth.JWTLocalVerifyPublicKeyBase64 = v
 	}
+
+	return applyTokenEnvOverrides(config)
+}
+
+// applyTokenEnvOverrides scans TOKEN_<NAME>__<FIELD> env vars and merges them
+// into config.Tokens. Double underscore separates the token name from the
+// field name so tokens with underscores in the name (wrapped_btc) parse
+// unambiguously. Tokens absent from yaml get Enabled=true by default —
+// matches GetTokenConfig's "unknown token = enabled" semantics, so a one-off
+// `TOKEN_FOO__INTERVAL_SECONDS=60` doesn't silently land disabled.
+func applyTokenEnvOverrides(config *Config) error {
+	const prefix = "TOKEN_"
+	const sep = "__"
+
+	if config.Tokens == nil {
+		config.Tokens = make(map[string]TokenConfig)
+	}
+
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq <= 0 {
+			continue
+		}
+		key, val := kv[:eq], kv[eq+1:]
+		if !strings.HasPrefix(key, prefix) || val == "" {
+			continue
+		}
+		rest := key[len(prefix):]
+		sepIdx := strings.Index(rest, sep)
+		if sepIdx <= 0 {
+			continue
+		}
+		tokenName := strings.ToLower(rest[:sepIdx])
+		field := rest[sepIdx+len(sep):]
+		if tokenName == "" || field == "" {
+			return fmt.Errorf("%s: malformed env var (expected TOKEN_<name>%s<field>)", key, sep)
+		}
+
+		tc, exists := config.Tokens[tokenName]
+		if !exists {
+			tc = TokenConfig{Enabled: true}
+		}
+		if err := applyTokenField(&tc, field, val); err != nil {
+			return fmt.Errorf("%s: %w", key, err)
+		}
+		config.Tokens[tokenName] = tc
+	}
+	return nil
+}
+
+func applyTokenField(tc *TokenConfig, field, val string) error {
+	switch field {
+	case "INTERVAL_SECONDS":
+		return parseIntInto(val, &tc.IntervalSeconds)
+	case "ENABLED":
+		return parseBoolInto(val, &tc.Enabled)
+	case "TIMEOUT_SECONDS":
+		return parseIntInto(val, &tc.TimeoutSeconds)
+	case "MIN_TIME_RANGE_SECONDS":
+		return parseIntInto(val, &tc.MinTimeRangeSeconds)
+	case "LIVE_LOOKBACK_SECONDS":
+		return parseIntInto(val, &tc.LiveLookbackSeconds)
+	case "MAX_CHUNK_MINUTES":
+		return parseIntInto(val, &tc.MaxChunkMinutes)
+	case "BACKFILL_ENABLED":
+		return parseBoolInto(val, &tc.Backfill.Enabled)
+	case "BACKFILL_START_FROM":
+		tc.Backfill.StartFrom = val
+		return nil
+	case "BACKFILL_CHUNK_MINUTES":
+		return parseIntInto(val, &tc.Backfill.ChunkMinutes)
+	default:
+		return fmt.Errorf("unknown token field %q", field)
+	}
+}
+
+func parseIntInto(s string, dst *int) error {
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return fmt.Errorf("invalid int %q: %w", s, err)
+	}
+	*dst = v
+	return nil
+}
+
+func parseBoolInto(s string, dst *bool) error {
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return fmt.Errorf("invalid bool %q: %w", s, err)
+	}
+	*dst = v
 	return nil
 }

--- a/internal/core/infrastructure/httpclient/counter.go
+++ b/internal/core/infrastructure/httpclient/counter.go
@@ -1,0 +1,38 @@
+package httpclient
+
+import (
+	"net/http"
+
+	"quotes/internal/metrics"
+)
+
+// WrapCounted increments metrics.OutboundHTTPRequestsTotal once per RoundTrip.
+// Sits between retry and base in the resilience stack so each attempt is
+// counted separately — subtracting outbound_http_retries_total yields the
+// number of logical requests from callers.
+func WrapCounted(next http.RoundTripper, component string) http.RoundTripper {
+	if next == nil {
+		next = http.DefaultTransport
+	}
+	if component == "" {
+		return next
+	}
+	return &countedTransport{next: next, component: component}
+}
+
+type countedTransport struct {
+	next      http.RoundTripper
+	component string
+}
+
+func (t *countedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.next.RoundTrip(req)
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode
+	}
+	metrics.OutboundHTTPRequestsTotal.
+		WithLabelValues(t.component, metrics.OutboundOutcome(status, err)).
+		Inc()
+	return resp, err
+}

--- a/internal/core/infrastructure/httpclient/resilience.go
+++ b/internal/core/infrastructure/httpclient/resilience.go
@@ -57,16 +57,20 @@ func (s ResilienceSettings) Normalized() ResilienceSettings {
 }
 
 // WrapResilientTransport returns base wrapped with retry, then optionally a circuit breaker (outermost).
-// Order: circuit breaker → retry → base.
+// Order: circuit breaker → retry → counter → base.
+// The counter sits inside retry so each attempt (including retries) increments
+// outbound_http_requests_total — `total - outbound_http_retries_total` then
+// gives logical-request count.
 func WrapResilientTransport(base http.RoundTripper, s ResilienceSettings) http.RoundTripper {
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	if s.CircuitBreakerDisabled && s.RetryMaxAttempts == 1 {
-		return base
-	}
 	s = s.Normalized()
-	rt := http.RoundTripper(&retryTransport{next: base, s: s})
+	counted := WrapCounted(base, s.Component)
+	if s.CircuitBreakerDisabled && s.RetryMaxAttempts == 1 {
+		return counted
+	}
+	rt := http.RoundTripper(&retryTransport{next: counted, s: s})
 	if !s.CircuitBreakerDisabled {
 		rt = newCircuitBreakerRoundTripper(s, rt)
 	}

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -46,6 +46,19 @@ var (
 		[]string{"component"},
 	)
 
+	// OutboundHTTPRequestsTotal counts every RoundTrip that actually hit the
+	// network — one increment per attempt, so retries are counted separately.
+	// `total - outbound_http_retries_total` ≈ logical requests issued by callers.
+	// outcome ∈ {2xx, 4xx, 5xx, error}; `error` covers network/transport errors
+	// where no HTTP status was received.
+	OutboundHTTPRequestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "outbound_http_requests_total",
+			Help: "Total outbound HTTP attempts (post-retry layer), labelled by component and outcome class.",
+		},
+		[]string{"component", "outcome"},
+	)
+
 	OutboundHTTPCircuitBreakerTransitionsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "outbound_http_circuit_breaker_transitions_total",
@@ -265,4 +278,14 @@ func StatusClass(code int) string {
 	default:
 		return "2xx"
 	}
+}
+
+// OutboundOutcome maps a RoundTrip result to the closed-enum label used by
+// OutboundHTTPRequestsTotal. Pass err != nil for transport-level failures
+// (status is ignored in that case).
+func OutboundOutcome(status int, err error) string {
+	if err != nil {
+		return "error"
+	}
+	return StatusClass(status)
 }


### PR DESCRIPTION
## Summary

- **`outbound_http_requests_total{component, outcome}`** - counts every CoinGecko/Equiteez attempt (outcome ∈ `2xx|4xx|5xx|error`). New `httpclient.WrapCounted` slots between retry and base, so `total - outbound_http_retries_total` = logical-request RPS. Closes the gap where the only way to estimate outbound load was multiplying `job_tick_duration_seconds_count` by the currency fan-out.
- **Per-token env overrides** - `TOKEN_<NAME>__<FIELD>` (double underscore) lets ops change `interval_seconds`, `enabled`, `backfill.*` etc. without editing `config.yaml`. Tokens absent from yaml default to `Enabled=true`, matching `GetTokenConfig` semantics. Env wins over yaml.
- **Grafana** - 4 new panels in the Outbound HTTP row: RPS by component, by outcome, 1h totals, error-ratio. Lower rows shifted +12. Version bumped 2 → 3.
- **`.env` + `.env.example`** - commented examples for MVRK/USDT, full field list documented.

## Files

- `internal/metrics/prometheus.go` - new `OutboundHTTPRequestsTotal` + `OutboundOutcome()` helper.
- `internal/core/infrastructure/httpclient/counter.go` - new `WrapCounted` transport.
- `internal/core/infrastructure/httpclient/resilience.go` - stack reorder: `CB → retry → counter → base`.
- `internal/config/env.go` - `applyTokenEnvOverrides` scans `TOKEN_*__*` from `os.Environ()`.
- `grafana/dashboards/mavryk-external-data.json` - panels 15–18, layout shift.
- `.env`, `.env.example` - documented overrides for MVRK/USDT (commented out so yaml stays authoritative).
