### PR TITLE
Adds /v1/tickers/:token/latest and /distribution backed by a CoinGecko

### DIFF
--- a/cmd/quotes/main.go
+++ b/cmd/quotes/main.go
@@ -19,6 +19,7 @@ import (
 	"quotes/internal/config"
 	httpapp "quotes/internal/core/api/http"
 	apiprices "quotes/internal/core/application/prices"
+	apitickers "quotes/internal/core/application/tickers"
 	"quotes/internal/core/domain/prices"
 	"quotes/internal/core/infrastructure/httpclient"
 	"quotes/internal/core/infrastructure/jobs"
@@ -88,6 +89,14 @@ func run() int {
 	// Change repos for /change endpoints. Read-only; share the GORM handle.
 	tokenChangeRepo := repositories.NewTokenChangeRepository(db.DB)
 	rwaChangeRepo := repositories.NewRWAChangeRepository(db.DB)
+	// Ticker repo + cache decorator. Two TTLs because /latest and /distribution
+	// have different cost / call-rate profiles (see ADR-0007 / Q1).
+	tickerRepo := repositories.NewTickerRepository(db.DB).WithBatchSize(batch)
+	tickerAppRepo := apitickers.NewCachedRepository(
+		tickerRepo,
+		time.Duration(cfg.Tickers.Cache.LatestTTLSeconds)*time.Second,
+		time.Duration(cfg.Tickers.Cache.DistributionTTLSeconds)*time.Second,
+	)
 
 	// Application repositories: cache decorator on top, used by HTTP and by jobs
 	// (jobs write through, decorator invalidates).
@@ -118,6 +127,7 @@ func run() int {
 		RWAChangeRepo:   rwaChangeRepo,
 		FXConverter:     fxConverter,
 		Lookup:          lookup,
+		TickerQuery:     tickerAppRepo,
 	})
 	if err != nil {
 		logger.Error().Err(err).Msg("http_app_init_failed")
@@ -128,6 +138,7 @@ func run() int {
 	backfillJob := jobs.NewCoinGeckoBackfillJob(cfg, tokenAppRepo, tokenRepo, stateRepo, logger)
 	rwaJob := jobs.NewEquiteezRWAJob(cfg, rwaAppRepo, lookup, logger)
 	rwaBackfillJob := jobs.NewEquiteezBackfillJob(cfg, rwaAppRepo, lookup, stateRepo, logger)
+	tickersJob := jobs.NewCoinGeckoTickersJob(cfg, tickerAppRepo, logger)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -163,6 +174,7 @@ func run() int {
 
 	rwaJob.Start(ctx)
 	rwaBackfillJob.Start(ctx)
+	tickersJob.Start(ctx)
 
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
@@ -195,6 +207,7 @@ func run() int {
 	backfillJob.Stop()
 	rwaJob.Stop()
 	rwaBackfillJob.Stop()
+	tickersJob.Stop()
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer shutdownCancel()

--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,10 @@ server:
   latest_quote_cache_ttl_seconds: 5
   # Hard cap on the ?limit= query param. 0 = use compiled default (10000).
   max_query_limit: 10000
+  # /v1/tickers/:token/latest hides rows whose `ts` is older than this by default.
+  # `?include_stale=true` returns them with is_stale=true. /distribution always
+  # excludes stale rows regardless of caller flag.
+  ticker_stale_after: "1h"
   pprof_enabled: false
   # Per-handler ctx timeout (request budget). 0 disables.
   handler_timeout: "10s"
@@ -107,6 +111,19 @@ rwa:
   enabled: false
   interval_seconds: 60
   concurrency: 4
+
+# Per-exchange ticker collector. Polls CoinGecko /coins/{id}/tickers on a fixed
+# cadence and serves /v1/tickers/:token/latest + /distribution.
+# Default off — flip after migrations 0012/0013/0014 are applied.
+tickers:
+  enabled: false
+  token_symbol: "mvrk"
+  interval_seconds: 300
+  http_timeout: "10s"
+  include_exchange_logo: true
+  cache:
+    latest_ttl_seconds: 30
+    distribution_ttl_seconds: 60
 
 # MBIO JWT verification for the public listener's RWA routes (/v1/rwa/*,
 # /v1/pairs/rwa). Internal listener traffic skips this entirely.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	Equiteez  EquiteezConfig         `yaml:"equiteez"`
 	Backfill  BackfillConfig         `yaml:"backfill"`
 	RWA       RWAConfig              `yaml:"rwa"`
+	Tickers   TickersConfig          `yaml:"tickers"`
 	Auth      AuthConfig             `yaml:"auth"`
 	Tokens    map[string]TokenConfig `yaml:"tokens"`
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -36,6 +36,9 @@ func setDefaults(config *Config) {
 	if config.Server.MaxInCurrencies == 0 {
 		config.Server.MaxInCurrencies = 10
 	}
+	if config.Server.TickerStaleAfter == 0 {
+		config.Server.TickerStaleAfter = DurationYAML(60 * time.Minute)
+	}
 	if len(config.Server.CORS.AllowedOrigins) == 0 {
 		config.Server.CORS.AllowedOrigins = []string{
 			"http://localhost:3010",
@@ -144,5 +147,24 @@ func setDefaults(config *Config) {
 	}
 	if config.RWA.Concurrency == 0 && config.RWA.Enabled {
 		config.RWA.Concurrency = 4
+	}
+
+	// Tickers defaults — only the cache TTLs are eager; the rest stay zero
+	// unless explicitly enabled in YAML so a fresh service doesn't start
+	// hammering CG without an operator decision.
+	if config.Tickers.TokenSymbol == "" {
+		config.Tickers.TokenSymbol = "mvrk"
+	}
+	if config.Tickers.IntervalSeconds == 0 {
+		config.Tickers.IntervalSeconds = 300 // 5 min
+	}
+	if config.Tickers.HTTPTimeout == 0 {
+		config.Tickers.HTTPTimeout = DurationYAML(10 * time.Second)
+	}
+	if config.Tickers.Cache.LatestTTLSeconds == 0 {
+		config.Tickers.Cache.LatestTTLSeconds = 30
+	}
+	if config.Tickers.Cache.DistributionTTLSeconds == 0 {
+		config.Tickers.Cache.DistributionTTLSeconds = 60
 	}
 }

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -40,8 +40,13 @@ type ServerConfig struct {
 	// MaxInCurrencies — cap on the number of comma-separated currencies a
 	// single request may pass to `?in=`. Defends against `?in=usd,eur,...`
 	// spam. 0 means use the in-code default (10).
-	MaxInCurrencies int        `yaml:"max_in_currencies"`
-	CORS            CORSConfig `yaml:"cors"`
+	MaxInCurrencies int `yaml:"max_in_currencies"`
+	// TickerStaleAfter — /v1/tickers/:token/latest hides rows whose `ts` is
+	// older than now-TickerStaleAfter by default. Opt-in `?include_stale=true`
+	// returns them with is_stale=true. /distribution always excludes stale
+	// rows regardless of caller flag. 0 means use the in-code default (1h).
+	TickerStaleAfter DurationYAML `yaml:"ticker_stale_after"`
+	CORS             CORSConfig   `yaml:"cors"`
 }
 
 // ServerRateLimitConfig controls inbound HTTP throttling.

--- a/internal/config/tickers.go
+++ b/internal/config/tickers.go
@@ -1,0 +1,24 @@
+package config
+
+// TickersConfig controls the CoinGecko tickers job and the in-process snapshot
+// cache for /v1/tickers/:token/latest and /distribution.
+//
+// MVRK-only in v1: TokenSymbol is a single string. When we add a second token
+// (USDT or DEX phase 2), flip to []string and reintroduce the concurrency cap
+// used by JobConfig.
+type TickersConfig struct {
+	Enabled             bool               `yaml:"enabled"`
+	TokenSymbol         string             `yaml:"token_symbol"`
+	IntervalSeconds     int                `yaml:"interval_seconds"`
+	HTTPTimeout         DurationYAML       `yaml:"http_timeout"`
+	IncludeExchangeLogo bool               `yaml:"include_exchange_logo"`
+	Cache               TickersCacheConfig `yaml:"cache"`
+}
+
+// TickersCacheConfig sets the per-endpoint cache TTL. Separate knobs because
+// /distribution costs more to compute (GROUP BY) but is called less often, so
+// a longer TTL is cheaper at the same hit ratio.
+type TickersCacheConfig struct {
+	LatestTTLSeconds       int `yaml:"latest_ttl_seconds"`
+	DistributionTTLSeconds int `yaml:"distribution_ttl_seconds"`
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -27,6 +27,7 @@ func (c *Config) Validate() error {
 		c.validateEquiteezBackfill,
 		c.validateTokens,
 		c.validateRWA,
+		c.validateTickers,
 		c.validateAuth,
 		c.validateProductionSafety,
 	} {
@@ -67,6 +68,9 @@ func (c *Config) validateServer() error {
 	}
 	if c.Server.MaxInCurrencies < 0 {
 		return fmt.Errorf("server.max_in_currencies must be >= 0, got %d", c.Server.MaxInCurrencies)
+	}
+	if c.Server.TickerStaleAfter < 0 {
+		return fmt.Errorf("server.ticker_stale_after must be >= 0, got %s", time.Duration(c.Server.TickerStaleAfter))
 	}
 	if err := validatePositiveDuration("server.read_timeout", c.Server.ReadTimeout); err != nil {
 		return err
@@ -227,6 +231,29 @@ func (c *Config) validateEquiteezBackfill() error {
 	}
 	if err := validateBackfillStartFrom(b.StartFrom); err != nil {
 		return fmt.Errorf("equiteez.backfill.start_from: %w", err)
+	}
+	return nil
+}
+
+func (c *Config) validateTickers() error {
+	t := c.Tickers
+	if !t.Enabled {
+		return nil
+	}
+	if strings.TrimSpace(t.TokenSymbol) == "" {
+		return fmt.Errorf("tickers.token_symbol is required when tickers.enabled is true")
+	}
+	if t.IntervalSeconds <= 0 {
+		return fmt.Errorf("tickers.interval_seconds must be > 0 when tickers.enabled is true, got %d", t.IntervalSeconds)
+	}
+	if t.HTTPTimeout <= 0 {
+		return fmt.Errorf("tickers.http_timeout must be > 0 when tickers.enabled is true, got %s", time.Duration(t.HTTPTimeout))
+	}
+	if t.Cache.LatestTTLSeconds < 0 {
+		return fmt.Errorf("tickers.cache.latest_ttl_seconds must be >= 0")
+	}
+	if t.Cache.DistributionTTLSeconds < 0 {
+		return fmt.Errorf("tickers.cache.distribution_ttl_seconds must be >= 0")
 	}
 	return nil
 }

--- a/internal/core/api/http/app.go
+++ b/internal/core/api/http/app.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"time"
 
 	"quotes/internal/config"
 	"quotes/internal/core/api/http/handlers"
 	httpmw "quotes/internal/core/api/http/middleware"
 	apiprices "quotes/internal/core/application/prices"
+	apitickers "quotes/internal/core/application/tickers"
 	"quotes/internal/core/domain/prices"
 	"quotes/internal/core/infrastructure/storage/repositories"
 	"quotes/internal/logging"
@@ -38,6 +40,9 @@ type AppDeps struct {
 	// When either field is nil the handler rejects `?in=` with 400.
 	FXConverter apiprices.PriceConverter
 	Lookup      *repositories.LookupRepository
+	// TickerQuery powers /v1/tickers/:token/latest and /distribution. Nil
+	// disables the routes silently (no handlers mounted).
+	TickerQuery apitickers.QueryService
 }
 
 // App owns one or two HTTP servers:
@@ -268,6 +273,13 @@ func buildRouterDeps(deps AppDeps, cfg *config.Config, gate *handlers.ReadinessG
 		MaxInCurrencies: cfg.Server.MaxInCurrencies,
 	}
 	rwaPairsDeps := handlers.RWAPairsDeps{Lookup: deps.Lookup}
+	tickerDeps := handlers.TickerDeps{
+		Service:          deps.TickerQuery,
+		Converter:        deps.FXConverter,
+		DefaultSource:    prices.SourceCoinGecko,
+		MaxInCurrencies:  cfg.Server.MaxInCurrencies,
+		TickerStaleAfter: time.Duration(cfg.Server.TickerStaleAfter),
+	}
 	// Legacy /quotes — restored for downstream services that still pin to
 	// the v0.1.0 wide-format route. MVRK + CoinGecko only by design;
 	// hard-coded rather than registry-looked-up so a missing tokens row
@@ -288,6 +300,7 @@ func buildRouterDeps(deps AppDeps, cfg *config.Config, gate *handlers.ReadinessG
 		RWAPairs:      rwaPairsDeps,
 		Change:        changeDeps,
 		LegacyQuotes:  legacyQuotesDeps,
+		Ticker:        tickerDeps,
 	}
 }
 

--- a/internal/core/api/http/handlers/tickers.go
+++ b/internal/core/api/http/handlers/tickers.go
@@ -1,0 +1,502 @@
+package handlers
+
+import (
+	"context"
+	stderrors "errors"
+	"strings"
+	"time"
+
+	"quotes/internal/core/api/http/common"
+	apiprices "quotes/internal/core/application/prices"
+	apitickers "quotes/internal/core/application/tickers"
+	coreerrors "quotes/internal/core/common/errors"
+	"quotes/internal/core/domain/prices"
+	"quotes/internal/core/domain/tickers"
+	"quotes/internal/metrics"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+)
+
+// TickerDeps wires the tickers HTTP layer.
+//
+// Converter is optional — when nil, requests with ?in= return 400 (matches the
+// RWA endpoints under the same posture). Source defaults to CoinGecko.
+type TickerDeps struct {
+	Service          apitickers.QueryService
+	Converter        apiprices.PriceConverter
+	DefaultSource    prices.Source
+	MaxInCurrencies  int
+	TickerStaleAfter time.Duration
+}
+
+// LatestByToken — GET /v1/tickers/:token/latest
+//
+// Query params:
+//
+//	?in=usd,eur,...           — convert price+volume to these currencies (see ADR-0013)
+//	?include_stale=true       — return rows older than TickerStaleAfter (default hides them)
+//
+// Response: TickersSnapshotDTO. 200 on success (even with empty tickers — cold
+// start), 404 when token unknown, 400 on bad ?in= or unsupported currency.
+func (d TickerDeps) LatestByToken() gin.HandlerFunc {
+	type request struct {
+		Token        prices.Token
+		Source       prices.Source
+		IncludeStale bool
+		InTargets    []prices.Currency
+	}
+	bind := func(c *gin.Context) (request, error) {
+		tok, err := parseTokenParam(c)
+		if err != nil {
+			return request{}, err
+		}
+		inTargets, err := d.parseInQuery(c)
+		if err != nil {
+			return request{}, err
+		}
+		return request{
+			Token:        tok,
+			Source:       d.DefaultSource,
+			IncludeStale: parseBoolQuery(c, "include_stale", false),
+			InTargets:    inTargets,
+		}, nil
+	}
+	action := func(ctx context.Context, req request) (TickersSnapshotDTO, error) {
+		snap, err := d.Service.LatestSnapshot(ctx, apitickers.LatestQuery{
+			Token:        req.Token,
+			Source:       req.Source,
+			IncludeStale: req.IncludeStale,
+			StaleAfter:   d.TickerStaleAfter,
+		})
+		if err != nil {
+			return TickersSnapshotDTO{}, err
+		}
+		return d.buildSnapshotDTO(ctx, req.Token, snap, req.InTargets), nil
+	}
+	return common.Wrap(bind, action)
+}
+
+// Distribution — GET /v1/tickers/:token/distribution?group_by=exchange|target&in=usd
+//
+// Returns one row per group with summed volume and share_pct. Stale rows are
+// always excluded server-side regardless of any caller flag — the pie chart is
+// about current market structure, not historical noise.
+func (d TickerDeps) Distribution() gin.HandlerFunc {
+	type request struct {
+		Token     prices.Token
+		Source    prices.Source
+		GroupBy   tickers.GroupBy
+		InTargets []prices.Currency
+	}
+	bind := func(c *gin.Context) (request, error) {
+		tok, err := parseTokenParam(c)
+		if err != nil {
+			return request{}, err
+		}
+		gb, err := tickers.NewGroupBy(c.Query("group_by"))
+		if err != nil {
+			return request{}, coreerrors.InvalidArgument(err.Error())
+		}
+		inTargets, err := d.parseInQuery(c)
+		if err != nil {
+			return request{}, err
+		}
+		return request{
+			Token:     tok,
+			Source:    d.DefaultSource,
+			GroupBy:   gb,
+			InTargets: inTargets,
+		}, nil
+	}
+	action := func(ctx context.Context, req request) (DistributionDTO, error) {
+		dist, err := d.Service.VolumeDistribution(ctx, apitickers.DistributionQuery{
+			Token:      req.Token,
+			Source:     req.Source,
+			GroupBy:    req.GroupBy,
+			StaleAfter: d.TickerStaleAfter,
+		})
+		if err != nil {
+			return DistributionDTO{}, err
+		}
+		return d.buildDistributionDTO(ctx, req.Token, dist, req.InTargets), nil
+	}
+	return common.Wrap(bind, action)
+}
+
+// --- bind helpers ---
+
+func parseTokenParam(c *gin.Context) (prices.Token, error) {
+	raw := strings.TrimSpace(c.Param("token"))
+	if raw == "" {
+		return "", coreerrors.InvalidArgument("token path parameter is required")
+	}
+	tok, err := prices.NewToken(raw)
+	if err != nil {
+		return "", coreerrors.NotFound("Token not found")
+	}
+	return tok, nil
+}
+
+func parseBoolQuery(c *gin.Context, key string, def bool) bool {
+	v := strings.ToLower(strings.TrimSpace(c.Query(key)))
+	switch v {
+	case "", "0", "false", "no":
+		return def && v == ""
+	case "1", "true", "yes":
+		return true
+	default:
+		return def
+	}
+}
+
+// parseInQuery mirrors the RWA pattern (rwa_prices.go). Empty returns nil.
+// Unknown values or > MaxInCurrencies → 400.
+func (d TickerDeps) parseInQuery(c *gin.Context) ([]prices.Currency, error) {
+	raw := strings.TrimSpace(c.Query("in"))
+	if raw == "" {
+		return nil, nil
+	}
+	if d.Converter == nil {
+		return nil, coreerrors.InvalidArgument("'?in=' is not enabled on this server")
+	}
+	parts := strings.Split(raw, ",")
+	if d.MaxInCurrencies > 0 && len(parts) > d.MaxInCurrencies {
+		return nil, coreerrors.InvalidArgument("Too many currencies in 'in'; cap is configured server-side")
+	}
+	out := make([]prices.Currency, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(strings.ToLower(p))
+		if p == "" {
+			continue
+		}
+		cur, err := prices.NewCurrency(p)
+		if err != nil {
+			return nil, coreerrors.InvalidArgument("Invalid 'in' currency: " + p)
+		}
+		out = append(out, cur)
+	}
+	return out, nil
+}
+
+// --- DTOs ---
+
+// TickersSnapshotDTO is the on-wire shape for /v1/tickers/:token/latest.
+type TickersSnapshotDTO struct {
+	Source    string         `json:"source"`
+	Entity    string         `json:"entity"`
+	Timestamp string         `json:"timestamp"`
+	Tickers   []TickerRowDTO `json:"tickers"`
+}
+
+// TickerRowDTO is one (exchange, target) row.
+type TickerRowDTO struct {
+	Exchange        string                          `json:"exchange"` // identifier (lookup key)
+	ExchangeName    string                          `json:"exchange_name"`
+	ExchangeKind    string                          `json:"exchange_kind"` // "cex" / "dex"
+	LogoURL         string                          `json:"logo_url,omitempty"`
+	Target          string                          `json:"target"`
+	Pair            string                          `json:"pair"`                      // "MVRK/BTC"
+	LastPrice       string                          `json:"last_price"`                // native; in `target` units
+	VolumeBase      *string                         `json:"volume_24h_base,omitempty"` // in token units
+	Change24hPct    *string                         `json:"change_24h_pct"`            // null when no 24h-ago row
+	BidAskSpreadPct *string                         `json:"bid_ask_spread_pct,omitempty"`
+	TrustScore      string                          `json:"trust_score,omitempty"`
+	IsStale         bool                            `json:"is_stale"`
+	IsAnomaly       bool                            `json:"is_anomaly"`
+	TradeURL        string                          `json:"trade_url,omitempty"`
+	In              map[string]ConvertedTickerBlock `json:"in,omitempty"`
+}
+
+// ConvertedTickerBlock carries the per-`?in=` projection for one row.
+//
+// Either Price+Volume are present (success) or FX.Error is populated and the
+// numeric fields are omitted (per-target failure, parent response stays 200).
+type ConvertedTickerBlock struct {
+	Price     string  `json:"price,omitempty"`
+	Volume24h *string `json:"volume_24h,omitempty"`
+	FX        FXMeta  `json:"fx"`
+}
+
+// FXMeta — same shape used by RWA `?in=` responses for cross-route consistency.
+type FXMeta struct {
+	Rate   string `json:"rate,omitempty"`
+	Source string `json:"source,omitempty"`
+	TS     string `json:"ts,omitempty"`
+	Method string `json:"method,omitempty"` // "rate" | "identity"
+	Stale  bool   `json:"stale,omitempty"`
+	Error  string `json:"error,omitempty"` // "no_rate" | "unsupported_target" | "unregistered_source"
+}
+
+// DistributionDTO is the on-wire shape for /v1/tickers/:token/distribution.
+type DistributionDTO struct {
+	Source          string               `json:"source"`
+	Entity          string               `json:"entity"`
+	Timestamp       string               `json:"timestamp"`
+	GroupBy         string               `json:"group_by"`
+	TotalVolumeBase string               `json:"total_volume_base"`
+	Rows            []DistributionRowDTO `json:"rows"`
+}
+
+// DistributionRowDTO is one slice of the pie.
+type DistributionRowDTO struct {
+	// Exchange grouping fields (group_by=exchange).
+	Exchange     string `json:"exchange,omitempty"`
+	ExchangeName string `json:"exchange_name,omitempty"`
+	LogoURL      string `json:"logo_url,omitempty"`
+	ExchangeKind string `json:"exchange_kind,omitempty"`
+	// Target grouping field (group_by=target).
+	Target string `json:"target,omitempty"`
+
+	VolumeBase string                          `json:"volume_24h_base"`
+	SharePct   string                          `json:"share_pct"`
+	In         map[string]ConvertedVolumeBlock `json:"in,omitempty"`
+}
+
+// ConvertedVolumeBlock is a slimmer version of ConvertedTickerBlock — pie rows
+// only convert volume, never a price.
+type ConvertedVolumeBlock struct {
+	Volume24h string `json:"volume_24h,omitempty"`
+	FX        FXMeta `json:"fx"`
+}
+
+// --- DTO builders ---
+
+func (d TickerDeps) buildSnapshotDTO(
+	ctx context.Context,
+	token prices.Token,
+	snap tickers.Snapshot,
+	inTargets []prices.Currency,
+) TickersSnapshotDTO {
+	out := TickersSnapshotDTO{
+		Source:    string(snap.Source),
+		Entity:    string(snap.Token),
+		Timestamp: formatTime(snap.Timestamp),
+		Tickers:   make([]TickerRowDTO, 0, len(snap.Rows)),
+	}
+	if snap.Token == "" {
+		out.Entity = string(token)
+	}
+	for _, r := range snap.Rows {
+		row := TickerRowDTO{
+			Exchange:        r.Exchange.ID,
+			ExchangeName:    r.Exchange.Name,
+			ExchangeKind:    string(r.Exchange.Kind),
+			LogoURL:         r.Exchange.LogoURL,
+			Target:          r.TargetSymbol,
+			Pair:            strings.ToUpper(string(token)) + "/" + strings.ToUpper(r.TargetSymbol),
+			LastPrice:       formatDec(r.LastPrice),
+			VolumeBase:      optDec(r.VolumeBase),
+			Change24hPct:    optDec(r.Change24hPct),
+			BidAskSpreadPct: optDec(r.BidAskSpread),
+			TrustScore:      r.TrustScore,
+			IsStale:         r.IsStale,
+			IsAnomaly:       r.IsAnomaly,
+			TradeURL:        r.TradeURL,
+		}
+		if len(inTargets) > 0 {
+			row.In = d.convertRowTargets(ctx, token, r, inTargets)
+		}
+		out.Tickers = append(out.Tickers, row)
+	}
+	return out
+}
+
+func (d TickerDeps) buildDistributionDTO(
+	ctx context.Context,
+	token prices.Token,
+	dist tickers.Distribution,
+	inTargets []prices.Currency,
+) DistributionDTO {
+	out := DistributionDTO{
+		Source:          string(dist.Source),
+		Entity:          string(dist.Token),
+		Timestamp:       formatTime(dist.Timestamp),
+		GroupBy:         string(dist.GroupBy),
+		TotalVolumeBase: formatDec(dist.Total),
+		Rows:            make([]DistributionRowDTO, 0, len(dist.Rows)),
+	}
+	if dist.Token == "" {
+		out.Entity = string(token)
+	}
+	for _, r := range dist.Rows {
+		row := DistributionRowDTO{
+			VolumeBase: formatDec(r.VolumeBase),
+			SharePct:   formatDec(r.SharePct),
+		}
+		if dist.GroupBy == tickers.GroupByExchange {
+			row.Exchange = r.Exchange.ID
+			row.ExchangeName = r.Exchange.Name
+			row.LogoURL = r.Exchange.LogoURL
+			row.ExchangeKind = string(r.Exchange.Kind)
+		} else {
+			row.Target = r.TargetSymbol
+		}
+		if len(inTargets) > 0 {
+			row.In = d.convertGroupVolumeTargets(ctx, token, r.VolumeBase, dist.Timestamp, inTargets)
+		}
+		out.Rows = append(out.Rows, row)
+	}
+	return out
+}
+
+// convertRowTargets builds the in.<target> map for one ticker row. The price
+// converts from `target_symbol` → currency (FX(target → currency) × last_price);
+// the volume converts from `token` → currency (FX(token → currency) × volume).
+// Per-target failures populate fx.error and omit the numeric fields. Parent
+// response stays 200.
+func (d TickerDeps) convertRowTargets(
+	ctx context.Context,
+	token prices.Token,
+	row tickers.SnapshotRow,
+	targets []prices.Currency,
+) map[string]ConvertedTickerBlock {
+	if d.Converter == nil {
+		return nil
+	}
+	out := make(map[string]ConvertedTickerBlock, len(targets))
+	// Resolve target_symbol → Token (so we can use it as a converter source).
+	targetTok, targetOK := promoteTickerTargetToken(row.TargetSymbol)
+
+	for _, cur := range targets {
+		block := ConvertedTickerBlock{}
+		// Price: target_symbol → cur.
+		if !targetOK {
+			block.FX = FXMeta{Error: "unregistered_source"}
+			metrics.FXConversionsTotal.WithLabelValues(row.TargetSymbol, string(cur), "unregistered_source").Inc()
+			out[string(cur)] = block
+			continue
+		}
+		priceRes, priceErr := timedConvert(ctx, d.Converter, targetTok, cur, row.LastPrice, row.Timestamp)
+		if priceErr != nil {
+			block.FX = FXMeta{Error: errToFXLabel(priceErr)}
+			out[string(cur)] = block
+			continue
+		}
+		block.Price = formatDec(priceRes.Amount)
+		block.FX = FXMeta{
+			Rate:   formatDec(priceRes.Rate),
+			Source: string(priceRes.Source),
+			TS:     formatTime(priceRes.RateTS),
+			Method: fxMethod(priceRes),
+			Stale:  priceRes.Stale,
+		}
+		if priceRes.Stale {
+			metrics.FXStaleResponsesTotal.WithLabelValues(string(cur)).Inc()
+		}
+
+		// Volume: token → cur. We use the token (e.g. mvrk) as the source so
+		// the converter looks up FX(mvrk → currency) — works whether the row
+		// is MVRK/BTC or MVRK/USDT.
+		if row.VolumeBase != nil {
+			volRes, volErr := timedConvert(ctx, d.Converter, token, cur, *row.VolumeBase, row.Timestamp)
+			if volErr == nil {
+				s := formatDec(volRes.Amount)
+				block.Volume24h = &s
+				if volRes.Stale {
+					metrics.FXStaleResponsesTotal.WithLabelValues(string(cur)).Inc()
+				}
+			}
+			// volume failure is silent — leave Volume24h nil but keep price block.
+		}
+		out[string(cur)] = block
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (d TickerDeps) convertGroupVolumeTargets(
+	ctx context.Context,
+	token prices.Token,
+	volumeBase decimal.Decimal,
+	ts time.Time,
+	targets []prices.Currency,
+) map[string]ConvertedVolumeBlock {
+	if d.Converter == nil {
+		return nil
+	}
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+	out := make(map[string]ConvertedVolumeBlock, len(targets))
+	for _, cur := range targets {
+		res, err := timedConvert(ctx, d.Converter, token, cur, volumeBase, ts)
+		if err != nil {
+			out[string(cur)] = ConvertedVolumeBlock{FX: FXMeta{Error: errToFXLabel(err)}}
+			continue
+		}
+		block := ConvertedVolumeBlock{
+			Volume24h: formatDec(res.Amount),
+			FX: FXMeta{
+				Rate:   formatDec(res.Rate),
+				Source: string(res.Source),
+				TS:     formatTime(res.RateTS),
+				Method: fxMethod(res),
+				Stale:  res.Stale,
+			},
+		}
+		if res.Stale {
+			metrics.FXStaleResponsesTotal.WithLabelValues(string(cur)).Inc()
+		}
+		out[string(cur)] = block
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// --- formatting + lookups ---
+
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format("2006-01-02T15:04:05Z")
+}
+
+func formatDec(d decimal.Decimal) string {
+	return d.String()
+}
+
+func optDec(p *decimal.Decimal) *string {
+	if p == nil {
+		return nil
+	}
+	s := p.String()
+	return &s
+}
+
+// promoteTickerTargetToken upgrades the ticker target_symbol string to a
+// registered Token (so PriceConverter.Convert can use it as a source). Returns
+// (zero, false) when the symbol isn't in the registry — handler drops that
+// row's converted block with fx.error="unregistered_source".
+func promoteTickerTargetToken(target string) (prices.Token, bool) {
+	tok, err := prices.NewToken(target)
+	if err != nil {
+		return "", false
+	}
+	return tok, true
+}
+
+func errToFXLabel(err error) string {
+	switch {
+	case stderrors.Is(err, apiprices.ErrNoFXRate):
+		return "no_rate"
+	case stderrors.Is(err, apiprices.ErrUnsupportedTargetCurrency):
+		return "unsupported_target"
+	case stderrors.Is(err, apiprices.ErrSourceTokenNotRegistered):
+		return "unregistered_source"
+	default:
+		return "query_error"
+	}
+}
+
+func fxMethod(r apiprices.ConversionResult) string {
+	if r.Identity {
+		return "identity"
+	}
+	return "rate"
+}

--- a/internal/core/api/http/handlers/tickers_test.go
+++ b/internal/core/api/http/handlers/tickers_test.go
@@ -1,0 +1,385 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	apiprices "quotes/internal/core/application/prices"
+	apitickers "quotes/internal/core/application/tickers"
+	"quotes/internal/core/domain/prices"
+	"quotes/internal/core/domain/tickers"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+)
+
+// --- stubs ---
+
+type stubTickerService struct {
+	snap    tickers.Snapshot
+	snapErr error
+	dist    tickers.Distribution
+	distErr error
+	latestQ apitickers.LatestQuery
+	distQ   apitickers.DistributionQuery
+}
+
+func (s *stubTickerService) LatestSnapshot(_ context.Context, q apitickers.LatestQuery) (tickers.Snapshot, error) {
+	s.latestQ = q
+	if s.snapErr != nil {
+		return tickers.Snapshot{}, s.snapErr
+	}
+	return s.snap, nil
+}
+
+func (s *stubTickerService) VolumeDistribution(_ context.Context, q apitickers.DistributionQuery) (tickers.Distribution, error) {
+	s.distQ = q
+	if s.distErr != nil {
+		return tickers.Distribution{}, s.distErr
+	}
+	return s.dist, nil
+}
+
+type stubTickerConverter struct {
+	results map[string]apiprices.ConversionResult
+	errors  map[string]error
+}
+
+func (s *stubTickerConverter) Convert(
+	_ context.Context,
+	src prices.Token,
+	target prices.Currency,
+	amount decimal.Decimal,
+	ts time.Time,
+) (apiprices.ConversionResult, error) {
+	key := string(src) + "->" + string(target)
+	if err, ok := s.errors[key]; ok {
+		return apiprices.ConversionResult{}, err
+	}
+	if r, ok := s.results[key]; ok {
+		// scale amount × rate so output looks like a real conversion
+		r.Amount = amount.Mul(r.Rate)
+		if r.RateTS.IsZero() {
+			r.RateTS = ts
+		}
+		return r, nil
+	}
+	return apiprices.ConversionResult{}, apiprices.ErrNoFXRate
+}
+
+func registerTickerTestTokens(t *testing.T) {
+	t.Helper()
+	prices.RegisterTokens([]prices.TokenInfo{
+		{Symbol: "mvrk", Name: "Mavryk", Enabled: true, CoinGeckoID: "mavryk-network"},
+		{Symbol: "btc", Name: "Bitcoin", Enabled: true, CoinGeckoID: "bitcoin"},
+		{Symbol: "usdt", Name: "Tether", Enabled: true, CoinGeckoID: "tether"},
+	})
+}
+
+func newTickerEngine(deps TickerDeps) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/v1/tickers/:token/latest", deps.LatestByToken())
+	r.GET("/v1/tickers/:token/distribution", deps.Distribution())
+	return r
+}
+
+// --- /latest tests ---
+
+func TestLatestByToken_HappyPath(t *testing.T) {
+	registerTickerTestTokens(t)
+	now := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
+	change := decimal.RequireFromString("5.34")
+	vol := decimal.RequireFromString("1234567.89")
+	snap := tickers.Snapshot{
+		Token: prices.Token("mvrk"), Source: prices.SourceCoinGecko, Timestamp: now,
+		Rows: []tickers.SnapshotRow{
+			{
+				Exchange:     tickers.Exchange{ID: "binance", Name: "Binance", Kind: tickers.ExchangeKindCEX, LogoURL: "https://x/b.png"},
+				TargetSymbol: "btc",
+				Timestamp:    now,
+				LastPrice:    decimal.RequireFromString("0.000021"),
+				VolumeBase:   &vol,
+				Change24hPct: &change,
+				TradeURL:     "https://binance.com/trade",
+				IsStale:      false,
+			},
+		},
+	}
+	deps := TickerDeps{
+		Service:          &stubTickerService{snap: snap},
+		DefaultSource:    prices.SourceCoinGecko,
+		TickerStaleAfter: time.Hour,
+	}
+	r := newTickerEngine(deps)
+	req := httptest.NewRequest(http.MethodGet, "/v1/tickers/mvrk/latest", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var got TickersSnapshotDTO
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Entity != "mvrk" || got.Source != "coingecko" {
+		t.Errorf("envelope: %+v", got)
+	}
+	if len(got.Tickers) != 1 {
+		t.Fatalf("tickers = %d", len(got.Tickers))
+	}
+	row := got.Tickers[0]
+	if row.Exchange != "binance" || row.Target != "btc" || row.Pair != "MVRK/BTC" {
+		t.Errorf("row keys: %+v", row)
+	}
+	if row.LogoURL != "https://x/b.png" || row.ExchangeKind != "cex" {
+		t.Errorf("row exchange meta: %+v", row)
+	}
+	if row.LastPrice != "0.000021" || row.Change24hPct == nil || *row.Change24hPct != "5.34" {
+		t.Errorf("numbers: %+v", row)
+	}
+}
+
+func TestLatestByToken_UnknownToken_404(t *testing.T) {
+	registerTickerTestTokens(t)
+	deps := TickerDeps{Service: &stubTickerService{}, DefaultSource: prices.SourceCoinGecko, TickerStaleAfter: time.Hour}
+	r := newTickerEngine(deps)
+	req := httptest.NewRequest(http.MethodGet, "/v1/tickers/ghost/latest", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d want 404 body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestLatestByToken_BadInCurrency_400(t *testing.T) {
+	registerTickerTestTokens(t)
+	deps := TickerDeps{
+		Service:          &stubTickerService{snap: tickers.Snapshot{Token: "mvrk"}},
+		Converter:        &stubTickerConverter{},
+		DefaultSource:    prices.SourceCoinGecko,
+		MaxInCurrencies:  10,
+		TickerStaleAfter: time.Hour,
+	}
+	r := newTickerEngine(deps)
+	req := httptest.NewRequest(http.MethodGet, "/v1/tickers/mvrk/latest?in=zzz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d want 400 body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestLatestByToken_InMissingConverter_400(t *testing.T) {
+	registerTickerTestTokens(t)
+	deps := TickerDeps{
+		Service:          &stubTickerService{},
+		Converter:        nil,
+		DefaultSource:    prices.SourceCoinGecko,
+		TickerStaleAfter: time.Hour,
+	}
+	r := newTickerEngine(deps)
+	req := httptest.NewRequest(http.MethodGet, "/v1/tickers/mvrk/latest?in=usd", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d want 400 (converter unavailable)", w.Code)
+	}
+}
+
+func TestLatestByToken_EmptySnapshot_200(t *testing.T) {
+	registerTickerTestTokens(t)
+	deps := TickerDeps{Service: &stubTickerService{snap: tickers.Snapshot{Token: "mvrk"}}, DefaultSource: prices.SourceCoinGecko, TickerStaleAfter: time.Hour}
+	r := newTickerEngine(deps)
+	req := httptest.NewRequest(http.MethodGet, "/v1/tickers/mvrk/latest", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d", w.Code)
+	}
+	var got TickersSnapshotDTO
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if len(got.Tickers) != 0 {
+		t.Errorf("tickers = %d want 0", len(got.Tickers))
+	}
+}
+
+func TestLatestByToken_IncludeStaleQuery_PassedThrough(t *testing.T) {
+	registerTickerTestTokens(t)
+	stub := &stubTickerService{snap: tickers.Snapshot{Token: "mvrk"}}
+	deps := TickerDeps{Service: stub, DefaultSource: prices.SourceCoinGecko, TickerStaleAfter: time.Hour}
+	r := newTickerEngine(deps)
+	req := httptest.NewRequest(http.MethodGet, "/v1/tickers/mvrk/latest?include_stale=true", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if !stub.latestQ.IncludeStale {
+		t.Errorf("IncludeStale flag not propagated to service")
+	}
+}
+
+func TestLatestByToken_WithInConvertsRowVolume(t *testing.T) {
+	registerTickerTestTokens(t)
+	now := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
+	vol := decimal.RequireFromString("1000")
+	snap := tickers.Snapshot{
+		Token: "mvrk", Source: prices.SourceCoinGecko, Timestamp: now,
+		Rows: []tickers.SnapshotRow{{
+			Exchange:     tickers.Exchange{ID: "binance", Name: "Binance", Kind: tickers.ExchangeKindCEX},
+			TargetSymbol: "btc",
+			Timestamp:    now,
+			LastPrice:    decimal.RequireFromString("0.000021"),
+			VolumeBase:   &vol,
+		}},
+	}
+	converter := &stubTickerConverter{results: map[string]apiprices.ConversionResult{
+		"btc->usd":  {Rate: decimal.RequireFromString("60000"), Source: prices.SourceCoinGecko},
+		"mvrk->usd": {Rate: decimal.RequireFromString("0.05"), Source: prices.SourceCoinGecko},
+	}}
+	deps := TickerDeps{
+		Service:          &stubTickerService{snap: snap},
+		Converter:        converter,
+		DefaultSource:    prices.SourceCoinGecko,
+		MaxInCurrencies:  10,
+		TickerStaleAfter: time.Hour,
+	}
+	r := newTickerEngine(deps)
+	req := httptest.NewRequest(http.MethodGet, "/v1/tickers/mvrk/latest?in=usd", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var got TickersSnapshotDTO
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Tickers) != 1 {
+		t.Fatalf("tickers = %d", len(got.Tickers))
+	}
+	block, ok := got.Tickers[0].In["usd"]
+	if !ok {
+		t.Fatalf("in.usd missing: %+v", got.Tickers[0])
+	}
+	// price = 0.000021 × 60000 = 1.26 (btc → usd)
+	if block.Price != "1.26" {
+		t.Errorf("price = %s want 1.26", block.Price)
+	}
+	// volume = 1000 × 0.05 = 50 (mvrk → usd)
+	if block.Volume24h == nil || *block.Volume24h != "50" {
+		t.Errorf("volume = %v want 50", block.Volume24h)
+	}
+}
+
+// --- /distribution tests ---
+
+func TestDistribution_HappyByExchange(t *testing.T) {
+	registerTickerTestTokens(t)
+	now := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
+	dist := tickers.Distribution{
+		Token: "mvrk", Source: prices.SourceCoinGecko, Timestamp: now, GroupBy: tickers.GroupByExchange,
+		Total: decimal.RequireFromString("2000"),
+		Rows: []tickers.DistributionRow{
+			{Exchange: tickers.Exchange{ID: "binance", Name: "Binance", Kind: tickers.ExchangeKindCEX},
+				VolumeBase: decimal.RequireFromString("1500"), SharePct: decimal.RequireFromString("75")},
+			{Exchange: tickers.Exchange{ID: "kraken", Name: "Kraken", Kind: tickers.ExchangeKindCEX},
+				VolumeBase: decimal.RequireFromString("500"), SharePct: decimal.RequireFromString("25")},
+		},
+	}
+	deps := TickerDeps{Service: &stubTickerService{dist: dist}, DefaultSource: prices.SourceCoinGecko, TickerStaleAfter: time.Hour}
+	r := newTickerEngine(deps)
+	req := httptest.NewRequest(http.MethodGet, "/v1/tickers/mvrk/distribution?group_by=exchange", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var got DistributionDTO
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.GroupBy != "exchange" || got.TotalVolumeBase != "2000" || len(got.Rows) != 2 {
+		t.Errorf("envelope: %+v", got)
+	}
+	if got.Rows[0].Exchange != "binance" || got.Rows[0].SharePct != "75" {
+		t.Errorf("row0: %+v", got.Rows[0])
+	}
+}
+
+func TestDistribution_HappyByTarget(t *testing.T) {
+	registerTickerTestTokens(t)
+	dist := tickers.Distribution{
+		Token: "mvrk", Source: prices.SourceCoinGecko, GroupBy: tickers.GroupByTarget,
+		Total: decimal.RequireFromString("1000"),
+		Rows: []tickers.DistributionRow{
+			{TargetSymbol: "btc", VolumeBase: decimal.RequireFromString("600"), SharePct: decimal.RequireFromString("60")},
+			{TargetSymbol: "usdt", VolumeBase: decimal.RequireFromString("400"), SharePct: decimal.RequireFromString("40")},
+		},
+	}
+	deps := TickerDeps{Service: &stubTickerService{dist: dist}, DefaultSource: prices.SourceCoinGecko, TickerStaleAfter: time.Hour}
+	r := newTickerEngine(deps)
+	req := httptest.NewRequest(http.MethodGet, "/v1/tickers/mvrk/distribution?group_by=target", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var got DistributionDTO
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if got.GroupBy != "target" || len(got.Rows) != 2 {
+		t.Errorf("got: %+v", got)
+	}
+	if got.Rows[0].Target != "btc" || got.Rows[0].Exchange != "" {
+		t.Errorf("by-target should not set exchange: %+v", got.Rows[0])
+	}
+}
+
+func TestDistribution_BadGroupBy_400(t *testing.T) {
+	registerTickerTestTokens(t)
+	deps := TickerDeps{Service: &stubTickerService{}, DefaultSource: prices.SourceCoinGecko, TickerStaleAfter: time.Hour}
+	r := newTickerEngine(deps)
+	for _, val := range []string{"", "foo", "by_exchange"} {
+		req := httptest.NewRequest(http.MethodGet, "/v1/tickers/mvrk/distribution?group_by="+val, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("group_by=%q: status = %d want 400", val, w.Code)
+		}
+	}
+}
+
+func TestDistribution_StaleFenceAlwaysApplied(t *testing.T) {
+	registerTickerTestTokens(t)
+	stub := &stubTickerService{dist: tickers.Distribution{Token: "mvrk", GroupBy: tickers.GroupByExchange}}
+	deps := TickerDeps{Service: stub, DefaultSource: prices.SourceCoinGecko, TickerStaleAfter: 90 * time.Minute}
+	r := newTickerEngine(deps)
+	// Even if a caller tries `?include_stale=true`, /distribution must always
+	// fence by StaleAfter (the handler doesn't read include_stale on this route).
+	req := httptest.NewRequest(http.MethodGet, "/v1/tickers/mvrk/distribution?group_by=exchange&include_stale=true", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if stub.distQ.StaleAfter != 90*time.Minute {
+		t.Errorf("StaleAfter = %v want 90m (forced by deps)", stub.distQ.StaleAfter)
+	}
+}
+
+func TestDistribution_UnknownToken_404(t *testing.T) {
+	registerTickerTestTokens(t)
+	deps := TickerDeps{Service: &stubTickerService{}, DefaultSource: prices.SourceCoinGecko, TickerStaleAfter: time.Hour}
+	r := newTickerEngine(deps)
+	req := httptest.NewRequest(http.MethodGet, "/v1/tickers/ghost/distribution?group_by=exchange", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d want 404", w.Code)
+	}
+}

--- a/internal/core/api/http/router.go
+++ b/internal/core/api/http/router.go
@@ -30,6 +30,7 @@ type RouterDeps struct {
 	RWAPairs      handlers.RWAPairsDeps
 	Change        handlers.ChangeDeps
 	LegacyQuotes  handlers.LegacyQuotesDeps
+	Ticker        handlers.TickerDeps
 	RWAAuth       gin.HandlerFunc
 	MountDocs     bool
 }
@@ -103,6 +104,16 @@ func SetupRoutes(engine *gin.Engine, deps RouterDeps) {
 			rwa.GET("/:symbol/series", deps.RWACharts.Series())
 			rwa.GET("/:symbol/ohlc", deps.RWACharts.OHLC())
 			rwa.GET("/:symbol/ohlcv", handlers.NotImplementedOHLCV())
+		}
+		// Per-exchange ticker market data (CoinGecko /coins/{id}/tickers).
+		// Open on both listeners — same posture as /v1/prices (FT data, not
+		// tenant-scoped). Mounted only when Ticker.Service is wired.
+		if deps.Ticker.Service != nil {
+			tk := v1.Group("/tickers")
+			{
+				tk.GET("/:token/latest", deps.Ticker.LatestByToken())
+				tk.GET("/:token/distribution", deps.Ticker.Distribution())
+			}
 		}
 		// Discovery group. Lives outside /v1/rwa because gin's radix
 		// tree won't accept a static segment next to /rwa/:symbol. Shares

--- a/internal/core/application/cache/ttl.go
+++ b/internal/core/application/cache/ttl.go
@@ -1,0 +1,130 @@
+// Package cache provides a generic in-process TTL cache used by the
+// per-domain CachedRepository decorators (prices, tickers, future kinds).
+//
+// The primitive intentionally stays small: get-or-load, invalidate-by-predicate,
+// and a passive TTL fence on lookup. Invalidation policy is owned by the
+// wrapping repository — see application/prices/cache.go and
+// application/tickers/cache.go for the (source, entity) and (token) variants
+// respectively.
+//
+// Zero TTL disables the cache transparently; lookups always miss, stores
+// no-op. This keeps the wrapper construction unconditional and removes
+// branchy "is cache enabled" checks from callers.
+package cache
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// TTL is a thread-safe generic TTL cache keyed by string.
+//
+// When clone is non-nil it runs on every store AND every lookup return — use
+// it to defend against caller aliasing for slice/map values. Pass nil when T
+// is a value type (struct of decimals, snapshot) and aliasing isn't possible.
+//
+// Concurrent miss-loaders are NOT single-flighted: two parallel GetOrLoad on
+// the same cold key both run load. Matches the existing prices cache
+// semantics; if duplicate work becomes measurable, add a singleflight here in
+// one place and every wrapper inherits it.
+type TTL[T any] struct {
+	ttl   time.Duration
+	mu    sync.RWMutex
+	store map[string]ttlEntry[T]
+	clone func(T) T
+}
+
+type ttlEntry[T any] struct {
+	expires time.Time
+	value   T
+}
+
+// New builds a cache. clone may be nil. ttl <= 0 disables caching.
+func New[T any](ttl time.Duration, clone func(T) T) *TTL[T] {
+	return &TTL[T]{
+		ttl:   ttl,
+		store: make(map[string]ttlEntry[T]),
+		clone: clone,
+	}
+}
+
+// Enabled reports whether the cache is active (positive TTL).
+func (c *TTL[T]) Enabled() bool { return c.ttl > 0 }
+
+// Lookup returns (value, true) on a fresh hit. Expired entries miss but stay
+// in the map until the next Invalidate sweep — cheap and bounded under
+// realistic write rates.
+func (c *TTL[T]) Lookup(key string) (T, bool) {
+	var zero T
+	if c.ttl <= 0 {
+		return zero, false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.store[key]
+	if !ok || time.Now().After(e.expires) {
+		return zero, false
+	}
+	if c.clone != nil {
+		return c.clone(e.value), true
+	}
+	return e.value, true
+}
+
+// Store records (key, value). No-op when ttl <= 0.
+func (c *TTL[T]) Store(key string, value T) {
+	if c.ttl <= 0 {
+		return
+	}
+	if c.clone != nil {
+		value = c.clone(value)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.store[key] = ttlEntry[T]{
+		expires: time.Now().Add(c.ttl),
+		value:   value,
+	}
+}
+
+// GetOrLoad returns the cached value on a hit; on a miss it calls load,
+// stores the result on success, and returns. Errors are NOT cached — the
+// next call retries.
+func (c *TTL[T]) GetOrLoad(ctx context.Context, key string, load func(context.Context) (T, error)) (T, error) {
+	if v, ok := c.Lookup(key); ok {
+		return v, nil
+	}
+	v, err := load(ctx)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	c.Store(key, v)
+	// Round-trip through Lookup to apply clone() consistently on the hot path.
+	if c.clone != nil {
+		return c.clone(v), nil
+	}
+	return v, nil
+}
+
+// Invalidate drops every entry whose key matches the predicate. O(n) over
+// the map; called from Save paths where n is bounded by ttl × write rate.
+func (c *TTL[T]) Invalidate(match func(key string) bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k := range c.store {
+		if match(k) {
+			delete(c.store, k)
+		}
+	}
+}
+
+// Purge drops every entry. Used by tests and by full-snapshot invalidation
+// paths (e.g. tickers job tick — the job rewrites the entire snapshot, so
+// matching on a specific (token) is wasteful when we can wipe).
+func (c *TTL[T]) Purge() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.store = make(map[string]ttlEntry[T])
+}

--- a/internal/core/application/cache/ttl_test.go
+++ b/internal/core/application/cache/ttl_test.go
@@ -1,0 +1,160 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func cloneInts(in []int) []int {
+	if in == nil {
+		return nil
+	}
+	out := make([]int, len(in))
+	copy(out, in)
+	return out
+}
+
+func TestTTL_HitMiss(t *testing.T) {
+	c := New[[]int](time.Minute, cloneInts)
+	if _, ok := c.Lookup("k"); ok {
+		t.Fatal("empty cache lookup must miss")
+	}
+	c.Store("k", []int{1, 2, 3})
+	v, ok := c.Lookup("k")
+	if !ok || len(v) != 3 || v[2] != 3 {
+		t.Fatalf("hit got %v ok=%v", v, ok)
+	}
+}
+
+func TestTTL_Expiry(t *testing.T) {
+	c := New[int](20*time.Millisecond, nil)
+	c.Store("k", 42)
+	if _, ok := c.Lookup("k"); !ok {
+		t.Fatal("fresh entry must hit")
+	}
+	time.Sleep(40 * time.Millisecond)
+	if _, ok := c.Lookup("k"); ok {
+		t.Fatal("expired entry must miss")
+	}
+}
+
+func TestTTL_DisabledNoCache(t *testing.T) {
+	c := New[int](0, nil)
+	if c.Enabled() {
+		t.Fatal("zero ttl must not be Enabled()")
+	}
+	c.Store("k", 1)
+	if _, ok := c.Lookup("k"); ok {
+		t.Fatal("disabled cache must miss after Store")
+	}
+}
+
+func TestTTL_GetOrLoadCachesSuccess(t *testing.T) {
+	c := New[int](time.Minute, nil)
+	var calls atomic.Int32
+	load := func(ctx context.Context) (int, error) {
+		calls.Add(1)
+		return 7, nil
+	}
+	for i := 0; i < 5; i++ {
+		v, err := c.GetOrLoad(context.Background(), "k", load)
+		if err != nil || v != 7 {
+			t.Fatalf("got %d err=%v", v, err)
+		}
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("loader calls = %d, want 1", calls.Load())
+	}
+}
+
+func TestTTL_GetOrLoadDoesNotCacheError(t *testing.T) {
+	c := New[int](time.Minute, nil)
+	boom := errors.New("boom")
+	calls := 0
+	load := func(ctx context.Context) (int, error) {
+		calls++
+		return 0, boom
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := c.GetOrLoad(context.Background(), "k", load); !errors.Is(err, boom) {
+			t.Fatalf("err = %v want %v", err, boom)
+		}
+	}
+	if calls != 3 {
+		t.Fatalf("loader calls = %d, want 3 (errors must not cache)", calls)
+	}
+}
+
+func TestTTL_InvalidatePredicate(t *testing.T) {
+	c := New[int](time.Minute, nil)
+	c.Store("mvrk:usd", 1)
+	c.Store("mvrk:eur", 2)
+	c.Store("usdt:usd", 3)
+	c.Invalidate(func(k string) bool {
+		return k == "mvrk:usd" || k == "mvrk:eur"
+	})
+	for _, k := range []string{"mvrk:usd", "mvrk:eur"} {
+		if _, ok := c.Lookup(k); ok {
+			t.Fatalf("%q should be evicted", k)
+		}
+	}
+	if v, ok := c.Lookup("usdt:usd"); !ok || v != 3 {
+		t.Fatalf("usdt:usd missing after partial invalidate")
+	}
+}
+
+func TestTTL_Purge(t *testing.T) {
+	c := New[int](time.Minute, nil)
+	c.Store("a", 1)
+	c.Store("b", 2)
+	c.Purge()
+	if _, ok := c.Lookup("a"); ok {
+		t.Fatal("Purge must drop entry a")
+	}
+	if _, ok := c.Lookup("b"); ok {
+		t.Fatal("Purge must drop entry b")
+	}
+}
+
+// TestTTL_CloneIsolatesCallers: callers mutating returned slices must not
+// poison the cache.
+func TestTTL_CloneIsolatesCallers(t *testing.T) {
+	c := New[[]int](time.Minute, cloneInts)
+	c.Store("k", []int{1, 2, 3})
+	got, _ := c.Lookup("k")
+	got[0] = 99
+	again, _ := c.Lookup("k")
+	if again[0] != 1 {
+		t.Fatalf("clone failed: cache poisoned, got %v", again)
+	}
+}
+
+// TestTTL_Race: run under -race; if locking is wrong the race detector trips.
+func TestTTL_Race(t *testing.T) {
+	c := New[int](time.Minute, nil)
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				_, _ = c.GetOrLoad(context.Background(), "k", func(context.Context) (int, error) { return i, nil })
+				_, _ = c.Lookup("k")
+			}
+		}(i)
+	}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				c.Invalidate(func(string) bool { return true })
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/core/application/prices/cache.go
+++ b/internal/core/application/prices/cache.go
@@ -2,9 +2,10 @@ package prices
 
 import (
 	"context"
-	"sync"
+	"strings"
 	"time"
 
+	"quotes/internal/core/application/cache"
 	"quotes/internal/core/domain/prices"
 )
 
@@ -16,24 +17,12 @@ import (
 // cache for the (Source, EntityKey) it wrote. This is conservative — readers
 // see their writes immediately, at the cost of dropping a possibly-still-fresh
 // entry. For our cadence (1–60 s ticks) this is the right tradeoff.
+//
+// Built on top of cache.TTL[[]PricePoint] — see internal/core/application/cache
+// for the generic primitive shared with the tickers domain.
 type CachedRepository struct {
 	inner Repository
-	ttl   time.Duration
-
-	mu    sync.RWMutex
-	cache map[cacheKey]cacheEntry
-}
-
-type cacheKey struct {
-	Source  prices.Source
-	Entity  string
-	Metrics string // joined sorted metrics list ("" for all)
-	Limit   int
-}
-
-type cacheEntry struct {
-	expires time.Time
-	points  []prices.PricePoint
+	cache *cache.TTL[[]prices.PricePoint]
 }
 
 // NewCachedRepository returns a decorator. ttl <= 0 disables caching transparently
@@ -41,8 +30,7 @@ type cacheEntry struct {
 func NewCachedRepository(inner Repository, ttl time.Duration) *CachedRepository {
 	return &CachedRepository{
 		inner: inner,
-		ttl:   ttl,
-		cache: make(map[cacheKey]cacheEntry),
+		cache: cache.New(ttl, cloneSlice),
 	}
 }
 
@@ -52,7 +40,7 @@ func (c *CachedRepository) Save(ctx context.Context, points []prices.PricePoint)
 	if err != nil {
 		return n, err
 	}
-	if n > 0 && c.ttl > 0 {
+	if n > 0 && c.cache.Enabled() {
 		c.invalidate(points)
 	}
 	return n, nil
@@ -60,72 +48,42 @@ func (c *CachedRepository) Save(ctx context.Context, points []prices.PricePoint)
 
 // Query consults the cache for IsLatest queries; otherwise passes through.
 func (c *CachedRepository) Query(ctx context.Context, q prices.Query) ([]prices.PricePoint, error) {
-	if c.ttl <= 0 || !q.IsLatest() {
+	if !c.cache.Enabled() || !q.IsLatest() {
 		return c.inner.Query(ctx, q)
 	}
 	key := keyFor(q)
-	if cached, ok := c.lookup(key); ok {
-		return cloneSlice(cached), nil
-	}
-	points, err := c.inner.Query(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-	c.store(key, cloneSlice(points))
-	return points, nil
+	return c.cache.GetOrLoad(ctx, key, func(ctx context.Context) ([]prices.PricePoint, error) {
+		return c.inner.Query(ctx, q)
+	})
 }
 
-func (c *CachedRepository) lookup(k cacheKey) ([]prices.PricePoint, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	entry, ok := c.cache[k]
-	if !ok || time.Now().After(entry.expires) {
-		return nil, false
-	}
-	return entry.points, true
-}
-
-func (c *CachedRepository) store(k cacheKey, points []prices.PricePoint) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.cache[k] = cacheEntry{
-		expires: time.Now().Add(c.ttl),
-		points:  points,
-	}
-}
-
-// invalidate drops every entry whose (source, entity) appears in points.
-// Fast-path: collect distinct keys first, then a single locked sweep.
+// invalidate drops every cache entry whose (source, entity) appears in points.
+// Cache keys encode (source, entity, metrics, limit) — we split on a sentinel
+// to recover (source, entity) cheaply without holding a parsed-key index.
 func (c *CachedRepository) invalidate(points []prices.PricePoint) {
-	affected := make(map[struct {
-		s prices.Source
-		e string
-	}]struct{}, 4)
+	type key struct {
+		source prices.Source
+		entity string
+	}
+	affected := make(map[key]struct{}, 4)
 	for _, p := range points {
-		affected[struct {
-			s prices.Source
-			e string
-		}{p.Source, p.EntityKey}] = struct{}{}
+		affected[key{p.Source, p.EntityKey}] = struct{}{}
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	for k := range c.cache {
-		if _, hit := affected[struct {
-			s prices.Source
-			e string
-		}{k.Source, k.Entity}]; hit {
-			delete(c.cache, k)
+	c.cache.Invalidate(func(k string) bool {
+		// key encoding: "src|entity|metrics|limit"; first two segments are
+		// what we match on.
+		parts := strings.SplitN(k, "|", 3)
+		if len(parts) < 2 {
+			return false
 		}
-	}
+		_, hit := affected[key{prices.Source(parts[0]), parts[1]}]
+		return hit
+	})
 }
 
-func keyFor(q prices.Query) cacheKey {
-	return cacheKey{
-		Source:  q.Source,
-		Entity:  q.EntityKey,
-		Metrics: joinSorted(q.Metrics),
-		Limit:   q.Limit,
-	}
+func keyFor(q prices.Query) string {
+	// Order: source | entity | metrics-joined-sorted | limit
+	return string(q.Source) + "|" + q.EntityKey + "|" + joinSorted(q.Metrics) + "|" + itoa(q.Limit)
 }
 
 func joinSorted(in []string) string {
@@ -142,10 +100,12 @@ func joinSorted(in []string) string {
 	}
 	out := cp[0]
 	for _, s := range cp[1:] {
-		out += "|" + s
+		out += "," + s
 	}
 	return out
 }
+
+// itoa: see changes.go (same package). Reused to keep cache keys allocation-free.
 
 func cloneSlice(in []prices.PricePoint) []prices.PricePoint {
 	if in == nil {

--- a/internal/core/application/tickers/cache.go
+++ b/internal/core/application/tickers/cache.go
@@ -1,0 +1,124 @@
+package tickers
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"quotes/internal/core/application/cache"
+	"quotes/internal/core/domain/tickers"
+)
+
+// CachedRepository wraps a Repository with per-endpoint TTL caches.
+//
+// Two independent caches because the two endpoints have different cost and
+// call-rate profiles:
+//   - /latest        — single DISTINCT ON + LATERAL, called every render
+//   - /distribution  — GROUP BY across all latest rows, called less often
+//
+// Both keys include IncludeStale / GroupBy / StaleAfter so a flip of any
+// dimension doesn't return a value from a sibling. SaveSnapshot invalidates
+// EVERYTHING for the touched token — the job rewrites the whole snapshot, so
+// keeping partial entries around is wasted memory.
+type CachedRepository struct {
+	inner        Repository
+	latest       *cache.TTL[tickers.Snapshot]
+	distribution *cache.TTL[tickers.Distribution]
+}
+
+// NewCachedRepository builds the decorator. Either ttl may be 0 to disable
+// that endpoint's cache; the wrapper still satisfies Repository.
+func NewCachedRepository(inner Repository, latestTTL, distributionTTL time.Duration) *CachedRepository {
+	return &CachedRepository{
+		inner:        inner,
+		latest:       cache.New(latestTTL, cloneSnapshot),
+		distribution: cache.New(distributionTTL, cloneDistribution),
+	}
+}
+
+// SaveSnapshot writes through and purges the caches for the affected token.
+// In v1 the job is single-token (MVRK) so a full Purge is the same as
+// per-token invalidate; we still scope by token to stay future-proof.
+func (c *CachedRepository) SaveSnapshot(
+	ctx context.Context,
+	exchanges []tickers.Exchange,
+	rows []tickers.Ticker,
+) (int64, error) {
+	n, err := c.inner.SaveSnapshot(ctx, exchanges, rows)
+	if err != nil {
+		return n, err
+	}
+	if n > 0 {
+		// Build the set of tokens we touched and drop matching cache keys.
+		affected := make(map[string]struct{}, 2)
+		for _, r := range rows {
+			affected[string(r.Token)] = struct{}{}
+		}
+		evict := func(key string) bool {
+			// Key encoding (see latestKey/distributionKey): "<token>|...".
+			// Compare by token prefix.
+			for tok := range affected {
+				if len(key) >= len(tok)+1 && key[:len(tok)] == tok && key[len(tok)] == '|' {
+					return true
+				}
+			}
+			return false
+		}
+		c.latest.Invalidate(evict)
+		c.distribution.Invalidate(evict)
+	}
+	return n, nil
+}
+
+func (c *CachedRepository) LatestSnapshot(ctx context.Context, q LatestQuery) (tickers.Snapshot, error) {
+	if !c.latest.Enabled() {
+		return c.inner.LatestSnapshot(ctx, q)
+	}
+	key := latestKey(q)
+	return c.latest.GetOrLoad(ctx, key, func(ctx context.Context) (tickers.Snapshot, error) {
+		return c.inner.LatestSnapshot(ctx, q)
+	})
+}
+
+func (c *CachedRepository) VolumeDistribution(ctx context.Context, q DistributionQuery) (tickers.Distribution, error) {
+	if !c.distribution.Enabled() {
+		return c.inner.VolumeDistribution(ctx, q)
+	}
+	key := distributionKey(q)
+	return c.distribution.GetOrLoad(ctx, key, func(ctx context.Context) (tickers.Distribution, error) {
+		return c.inner.VolumeDistribution(ctx, q)
+	})
+}
+
+func latestKey(q LatestQuery) string {
+	// token | source | includeStale | staleAfterMS
+	stale := "0"
+	if q.IncludeStale {
+		stale = "1"
+	}
+	return string(q.Token) + "|" + string(q.Source) + "|" + stale + "|" +
+		strconv.FormatInt(q.StaleAfter.Milliseconds(), 10)
+}
+
+func distributionKey(q DistributionQuery) string {
+	return string(q.Token) + "|" + string(q.Source) + "|" + string(q.GroupBy) + "|" +
+		strconv.FormatInt(q.StaleAfter.Milliseconds(), 10)
+}
+
+func cloneSnapshot(s tickers.Snapshot) tickers.Snapshot {
+	out := s
+	if s.Rows != nil {
+		out.Rows = make([]tickers.SnapshotRow, len(s.Rows))
+		copy(out.Rows, s.Rows)
+	}
+	return out
+}
+
+func cloneDistribution(d tickers.Distribution) tickers.Distribution {
+	out := d
+	if d.Rows != nil {
+		out.Rows = make([]tickers.DistributionRow, len(d.Rows))
+		copy(out.Rows, d.Rows)
+	}
+	return out
+}

--- a/internal/core/application/tickers/cache_test.go
+++ b/internal/core/application/tickers/cache_test.go
@@ -1,0 +1,180 @@
+package tickers
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"quotes/internal/core/domain/prices"
+	"quotes/internal/core/domain/tickers"
+
+	"github.com/shopspring/decimal"
+)
+
+// fakeRepo lets us count calls and replay arbitrary responses.
+type fakeRepo struct {
+	latestCalls       atomic.Int32
+	distributionCalls atomic.Int32
+	saveCalls         atomic.Int32
+	latestResp        tickers.Snapshot
+	distResp          tickers.Distribution
+	latestErr         error
+	distErr           error
+	saveN             int64
+}
+
+func (f *fakeRepo) SaveSnapshot(_ context.Context, _ []tickers.Exchange, _ []tickers.Ticker) (int64, error) {
+	f.saveCalls.Add(1)
+	return f.saveN, nil
+}
+
+func (f *fakeRepo) LatestSnapshot(_ context.Context, _ LatestQuery) (tickers.Snapshot, error) {
+	f.latestCalls.Add(1)
+	if f.latestErr != nil {
+		return tickers.Snapshot{}, f.latestErr
+	}
+	return f.latestResp, nil
+}
+
+func (f *fakeRepo) VolumeDistribution(_ context.Context, _ DistributionQuery) (tickers.Distribution, error) {
+	f.distributionCalls.Add(1)
+	if f.distErr != nil {
+		return tickers.Distribution{}, f.distErr
+	}
+	return f.distResp, nil
+}
+
+func mvrk() prices.Token { return prices.Token("mvrk") }
+
+func sampleSnapshot() tickers.Snapshot {
+	return tickers.Snapshot{
+		Token:     mvrk(),
+		Source:    prices.SourceCoinGecko,
+		Timestamp: time.Unix(1700000000, 0).UTC(),
+		Rows: []tickers.SnapshotRow{
+			{
+				Exchange:     tickers.Exchange{ID: "binance", Name: "Binance"},
+				TargetSymbol: "btc",
+				LastPrice:    decimal.RequireFromString("0.000021"),
+			},
+		},
+	}
+}
+
+func sampleDist() tickers.Distribution {
+	return tickers.Distribution{
+		Token:     mvrk(),
+		Source:    prices.SourceCoinGecko,
+		Timestamp: time.Unix(1700000000, 0).UTC(),
+		GroupBy:   tickers.GroupByExchange,
+		Total:     decimal.RequireFromString("1000"),
+		Rows: []tickers.DistributionRow{
+			{
+				Exchange:   tickers.Exchange{ID: "binance"},
+				VolumeBase: decimal.RequireFromString("1000"),
+				SharePct:   decimal.RequireFromString("100.000000"),
+			},
+		},
+	}
+}
+
+func TestCachedRepository_LatestServesCache(t *testing.T) {
+	inner := &fakeRepo{latestResp: sampleSnapshot()}
+	c := NewCachedRepository(inner, time.Minute, time.Minute)
+	q := LatestQuery{Token: mvrk(), Source: prices.SourceCoinGecko, IncludeStale: false, StaleAfter: time.Hour}
+	for i := 0; i < 5; i++ {
+		if _, err := c.LatestSnapshot(context.Background(), q); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := inner.latestCalls.Load(); got != 1 {
+		t.Fatalf("latestCalls = %d, want 1", got)
+	}
+}
+
+func TestCachedRepository_LatestKeyIncludesIncludeStale(t *testing.T) {
+	inner := &fakeRepo{latestResp: sampleSnapshot()}
+	c := NewCachedRepository(inner, time.Minute, time.Minute)
+	q1 := LatestQuery{Token: mvrk(), Source: prices.SourceCoinGecko, IncludeStale: false, StaleAfter: time.Hour}
+	q2 := q1
+	q2.IncludeStale = true
+	for _, q := range []LatestQuery{q1, q2, q1, q2} {
+		if _, err := c.LatestSnapshot(context.Background(), q); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := inner.latestCalls.Load(); got != 2 {
+		t.Fatalf("latestCalls = %d, want 2 (different include_stale must miss)", got)
+	}
+}
+
+func TestCachedRepository_DistributionKeyIncludesGroupBy(t *testing.T) {
+	inner := &fakeRepo{distResp: sampleDist()}
+	c := NewCachedRepository(inner, time.Minute, time.Minute)
+	q1 := DistributionQuery{Token: mvrk(), Source: prices.SourceCoinGecko, GroupBy: tickers.GroupByExchange, StaleAfter: time.Hour}
+	q2 := q1
+	q2.GroupBy = tickers.GroupByTarget
+	for _, q := range []DistributionQuery{q1, q2, q1, q2} {
+		if _, err := c.VolumeDistribution(context.Background(), q); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := inner.distributionCalls.Load(); got != 2 {
+		t.Fatalf("distributionCalls = %d, want 2 (different group_by must miss)", got)
+	}
+}
+
+func TestCachedRepository_SaveInvalidatesBoth(t *testing.T) {
+	inner := &fakeRepo{latestResp: sampleSnapshot(), distResp: sampleDist(), saveN: 5}
+	c := NewCachedRepository(inner, time.Minute, time.Minute)
+	ctx := context.Background()
+	_, _ = c.LatestSnapshot(ctx, LatestQuery{Token: mvrk(), Source: prices.SourceCoinGecko})
+	_, _ = c.VolumeDistribution(ctx, DistributionQuery{Token: mvrk(), Source: prices.SourceCoinGecko, GroupBy: tickers.GroupByExchange})
+	if inner.latestCalls.Load() != 1 || inner.distributionCalls.Load() != 1 {
+		t.Fatalf("setup: latestCalls=%d distCalls=%d", inner.latestCalls.Load(), inner.distributionCalls.Load())
+	}
+	// Save with rows for mvrk → both caches drop their mvrk entries.
+	_, err := c.SaveSnapshot(ctx, nil, []tickers.Ticker{{Token: mvrk(), Source: prices.SourceCoinGecko}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = c.LatestSnapshot(ctx, LatestQuery{Token: mvrk(), Source: prices.SourceCoinGecko})
+	_, _ = c.VolumeDistribution(ctx, DistributionQuery{Token: mvrk(), Source: prices.SourceCoinGecko, GroupBy: tickers.GroupByExchange})
+	if inner.latestCalls.Load() != 2 {
+		t.Errorf("latest miss after Save: latestCalls=%d want 2", inner.latestCalls.Load())
+	}
+	if inner.distributionCalls.Load() != 2 {
+		t.Errorf("distribution miss after Save: distCalls=%d want 2", inner.distributionCalls.Load())
+	}
+}
+
+func TestCachedRepository_LatestErrorNotCached(t *testing.T) {
+	boom := errors.New("boom")
+	inner := &fakeRepo{latestErr: boom}
+	c := NewCachedRepository(inner, time.Minute, time.Minute)
+	q := LatestQuery{Token: mvrk(), Source: prices.SourceCoinGecko}
+	for i := 0; i < 3; i++ {
+		if _, err := c.LatestSnapshot(context.Background(), q); !errors.Is(err, boom) {
+			t.Fatalf("err=%v want boom", err)
+		}
+	}
+	if got := inner.latestCalls.Load(); got != 3 {
+		t.Fatalf("latestCalls = %d, want 3 (errors must not cache)", got)
+	}
+}
+
+func TestCachedRepository_DisabledTTLPassesThrough(t *testing.T) {
+	inner := &fakeRepo{latestResp: sampleSnapshot()}
+	c := NewCachedRepository(inner, 0, 0)
+	q := LatestQuery{Token: mvrk(), Source: prices.SourceCoinGecko}
+	for i := 0; i < 3; i++ {
+		if _, err := c.LatestSnapshot(context.Background(), q); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := inner.latestCalls.Load(); got != 3 {
+		t.Fatalf("latestCalls = %d, want 3 (ttl=0 disables cache)", got)
+	}
+}

--- a/internal/core/application/tickers/repository.go
+++ b/internal/core/application/tickers/repository.go
@@ -1,0 +1,69 @@
+// Package tickers is the application layer for the ticker domain (per-exchange
+// CoinGecko data). Mirrors application/prices in shape: a Repository interface
+// over the storage layer plus a thin CachedRepository decorator.
+//
+// The Repository is intentionally narrow — only the queries the handler
+// surfaces, plus the write path used by the job. Adding a new query type means
+// a new method here, not a leaky GORM tx exposed to callers.
+package tickers
+
+import (
+	"context"
+	"time"
+
+	"quotes/internal/core/domain/prices"
+	"quotes/internal/core/domain/tickers"
+)
+
+// Repository is the read/write contract used by the HTTP handlers and the
+// CoinGecko tickers job. Implementations live under
+// internal/core/infrastructure/storage/repositories.
+type Repository interface {
+	// SaveSnapshot upserts the supplied exchanges into the lookup AND inserts
+	// the tickers into the hypertable inside a single transaction. The FK on
+	// token_tickers.exchange_id requires exchanges to land first, but the tx
+	// boundary ensures atomicity even when CG returns a brand-new exchange.
+	//
+	// Idempotent on (token, source, exchange, target, ts) — ON CONFLICT
+	// DO NOTHING absorbs duplicate ticks within a 5-minute cadence.
+	SaveSnapshot(ctx context.Context, exchanges []tickers.Exchange, rows []tickers.Ticker) (int64, error)
+
+	// LatestSnapshot returns one row per (exchange, target) for `token` from
+	// `source`, freshest first. When includeStale is false, rows whose
+	// `ts < now - staleAfter` are filtered out. Each row carries the 1D
+	// change % computed at query time via LATERAL against the same hypertable
+	// (see ADR-0013 §Consequences / TICKERS-4 for the escape-hatch CA).
+	//
+	// Empty result is not an error — handler returns 200 with an empty array.
+	LatestSnapshot(ctx context.Context, q LatestQuery) (tickers.Snapshot, error)
+
+	// VolumeDistribution returns one row per group (exchange or target) with
+	// the freshest-per-pair `volume_24h_base` summed inside each group. Stale
+	// rows (ts < now - staleAfter) are ALWAYS excluded — pie charts are about
+	// current market structure, never historical noise.
+	//
+	// When Total = 0 (cold start, all volumes nil), Rows is empty.
+	VolumeDistribution(ctx context.Context, q DistributionQuery) (tickers.Distribution, error)
+}
+
+// LatestQuery bundles read params for /v1/tickers/:token/latest.
+type LatestQuery struct {
+	Token        prices.Token
+	Source       prices.Source
+	IncludeStale bool
+	StaleAfter   time.Duration // 0 disables the stale fence regardless of IncludeStale
+}
+
+// DistributionQuery bundles read params for /v1/tickers/:token/distribution.
+type DistributionQuery struct {
+	Token      prices.Token
+	Source     prices.Source
+	GroupBy    tickers.GroupBy
+	StaleAfter time.Duration // 0 disables the stale fence
+}
+
+// QueryService is the read-only contract used by HTTP handlers.
+type QueryService interface {
+	LatestSnapshot(ctx context.Context, q LatestQuery) (tickers.Snapshot, error)
+	VolumeDistribution(ctx context.Context, q DistributionQuery) (tickers.Distribution, error)
+}

--- a/internal/core/domain/tickers/exchange_kind.go
+++ b/internal/core/domain/tickers/exchange_kind.go
@@ -1,0 +1,48 @@
+package tickers
+
+import "strings"
+
+// dexIdentifiers is the hard-coded allowlist of CoinGecko market.identifier
+// values that should be classified as DEX. Everything else falls through to
+// CEX (the safe default — misclassifying a DEX as CEX is a one-line fix; the
+// other direction is harder to spot).
+//
+// Sourced from CG's /exchanges?per_page=250 dump, filtered by centralized=false
+// (see https://api.coingecko.com/api/v3/exchanges). Update by appending; no
+// schema change.
+var dexIdentifiers = map[string]struct{}{
+	"uniswap_v2":         {},
+	"uniswap_v3":         {},
+	"uniswap_v4":         {},
+	"sushiswap":          {},
+	"pancakeswap_new":    {},
+	"pancakeswap":        {},
+	"pancakeswap_v3":     {},
+	"curve":              {},
+	"balancer":           {},
+	"raydium":            {},
+	"raydium2":           {},
+	"orca":               {},
+	"jupiter_aggregator": {},
+	"jupiter":            {},
+	"quickswap":          {},
+	"trader_joe":         {},
+	"camelot":            {},
+	"velodrome":          {},
+	"aerodrome":          {},
+	"meteora":            {},
+	"thorchain":          {},
+	"dodo":               {},
+	"hyperliquid":        {},
+	"plenty_network":     {},
+	"quipuswap":          {},
+}
+
+// ClassifyExchangeKind returns DEX when id is in the allowlist, otherwise CEX.
+// Case-insensitive on the input.
+func ClassifyExchangeKind(id string) ExchangeKind {
+	if _, ok := dexIdentifiers[strings.ToLower(strings.TrimSpace(id))]; ok {
+		return ExchangeKindDEX
+	}
+	return ExchangeKindCEX
+}

--- a/internal/core/domain/tickers/ticker.go
+++ b/internal/core/domain/tickers/ticker.go
@@ -1,0 +1,130 @@
+// Package tickers defines the domain types for CoinGecko per-exchange ticker
+// data (one row per (token, source, exchange, target_symbol, ts)).
+//
+// Ticker is the long-format row that lives in token_tickers; Snapshot is the
+// transposed read-model used by /v1/tickers/:token/latest. Exchange is the
+// lookup row for the exchanges table.
+//
+// Naming mirrors prices.PricePoint / prices.Snapshot so callers move between
+// FT/RWA/Ticker domains with minimal cognitive overhead.
+package tickers
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"quotes/internal/core/domain/prices"
+
+	"github.com/shopspring/decimal"
+)
+
+// ExchangeKind classifies an exchange. CG /tickers does not tag CEX vs DEX,
+// so we carry a hard-coded allowlist of well-known DEX identifiers in
+// exchange_kind.go; everything else is 'cex'. Trivial to extend.
+type ExchangeKind string
+
+const (
+	ExchangeKindCEX ExchangeKind = "cex"
+	ExchangeKindDEX ExchangeKind = "dex"
+)
+
+// Exchange is one row in the exchanges lookup table.
+type Exchange struct {
+	ID                  string       // CG market.identifier (PK)
+	Name                string       // CG market.name (human label)
+	LogoURL             string       // CG market.logo (Pro flag), may be empty
+	Kind                ExchangeKind // 'cex' default
+	HasTradingIncentive bool         // CG market.has_trading_incentive
+	LastSeenAt          time.Time    // updated on every observation
+}
+
+// Ticker is one row in the token_tickers hypertable. All numbers are native
+// units: LastPrice is in TargetSymbol units, VolumeBase is in the token (e.g.
+// MVRK count). Read-side conversion to ?in=usd,eur,... happens via the FX
+// PriceConverter at handler time (ADR-0013).
+type Ticker struct {
+	Token        prices.Token
+	Source       prices.Source
+	ExchangeID   string
+	TargetSymbol string // upstream quote symbol (lowercased: "btc", "usdt", "eth")
+	Timestamp    time.Time
+	LastPrice    decimal.Decimal  // price of 1 Token in TargetSymbol
+	VolumeBase   *decimal.Decimal // 24h volume in Token units; nil when upstream omits
+	BidAskSpread *decimal.Decimal // percent; nil when missing
+	TrustScore   string           // "green" / "yellow" / "red" / ""
+	IsAnomaly    bool
+	TradeURL     string
+	LastTradedAt time.Time // upstream last_traded_at; zero when missing
+}
+
+// Snapshot is the transposed read-model for GET /v1/tickers/:token/latest.
+// One row per (exchange, target) for one token, with the 1D change %
+// already joined in.
+type Snapshot struct {
+	Token     prices.Token
+	Source    prices.Source
+	Timestamp time.Time // newest ts across all rows
+	Rows      []SnapshotRow
+}
+
+// SnapshotRow is one (exchange, target) datapoint inside a Snapshot.
+type SnapshotRow struct {
+	Exchange     Exchange
+	TargetSymbol string
+	Timestamp    time.Time
+	LastPrice    decimal.Decimal
+	VolumeBase   *decimal.Decimal
+	BidAskSpread *decimal.Decimal
+	TrustScore   string
+	IsAnomaly    bool
+	IsStale      bool // derived: ts < now - server.ticker_stale_after
+	TradeURL     string
+	Change24hPct *decimal.Decimal // nil when no row exists at ts-24h
+}
+
+// GroupBy is the dimension over which /distribution aggregates volume. Closed
+// set — invalid values are rejected at the handler boundary.
+type GroupBy string
+
+const (
+	GroupByExchange GroupBy = "exchange"
+	GroupByTarget   GroupBy = "target"
+)
+
+// NewGroupBy validates an input string. Empty / unknown returns an error.
+func NewGroupBy(s string) (GroupBy, error) {
+	g := GroupBy(strings.ToLower(strings.TrimSpace(s)))
+	switch g {
+	case GroupByExchange, GroupByTarget:
+		return g, nil
+	default:
+		return "", fmt.Errorf("group_by must be 'exchange' or 'target', got %q", s)
+	}
+}
+
+// String implements fmt.Stringer.
+func (g GroupBy) String() string { return string(g) }
+
+// Distribution is the result of /v1/tickers/:token/distribution. Total is the
+// sum of VolumeBase across all returned rows; share_pct is derived per row.
+// When Total is zero (cold start, all volumes nil) Rows is empty.
+type Distribution struct {
+	Token     prices.Token
+	Source    prices.Source
+	Timestamp time.Time
+	GroupBy   GroupBy
+	Total     decimal.Decimal // sum of Rows[].VolumeBase, in Token units
+	Rows      []DistributionRow
+}
+
+// DistributionRow is one bar of the pie chart. Exactly one of Exchange.ID and
+// TargetSymbol is meaningful depending on Distribution.GroupBy:
+//   - GroupBy=exchange ⇒ Exchange populated (id+name+logo), TargetSymbol "".
+//   - GroupBy=target   ⇒ TargetSymbol populated, Exchange zero-valued.
+type DistributionRow struct {
+	Exchange     Exchange
+	TargetSymbol string
+	VolumeBase   decimal.Decimal // sum within the group, in Token units
+	SharePct     decimal.Decimal // VolumeBase / Distribution.Total * 100, 6dp
+}

--- a/internal/core/domain/tickers/ticker_test.go
+++ b/internal/core/domain/tickers/ticker_test.go
@@ -1,0 +1,51 @@
+package tickers
+
+import "testing"
+
+func TestNewGroupBy(t *testing.T) {
+	cases := []struct {
+		in    string
+		want  GroupBy
+		isErr bool
+	}{
+		{"exchange", GroupByExchange, false},
+		{"target", GroupByTarget, false},
+		{"EXCHANGE", GroupByExchange, false},
+		{"  target  ", GroupByTarget, false},
+		{"", "", true},
+		{"foo", "", true},
+		{"by_exchange", "", true},
+	}
+	for _, c := range cases {
+		got, err := NewGroupBy(c.in)
+		if (err != nil) != c.isErr {
+			t.Errorf("NewGroupBy(%q): err=%v want isErr=%v", c.in, err, c.isErr)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("NewGroupBy(%q): got %q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestClassifyExchangeKind(t *testing.T) {
+	cases := []struct {
+		in   string
+		want ExchangeKind
+	}{
+		{"binance", ExchangeKindCEX},
+		{"kraken", ExchangeKindCEX},
+		{"uniswap_v3", ExchangeKindDEX},
+		{"UNISWAP_V3", ExchangeKindDEX},
+		{"  raydium  ", ExchangeKindDEX},
+		{"", ExchangeKindCEX},
+		{"some-future-exchange", ExchangeKindCEX},
+		{"quipuswap", ExchangeKindDEX},
+	}
+	for _, c := range cases {
+		got := ClassifyExchangeKind(c.in)
+		if got != c.want {
+			t.Errorf("ClassifyExchangeKind(%q): got %q want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/core/infrastructure/interactions/coingecko/tickers.go
+++ b/internal/core/infrastructure/interactions/coingecko/tickers.go
@@ -1,0 +1,206 @@
+package coingecko
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"quotes/internal/core/domain/prices"
+	"quotes/internal/core/domain/tickers"
+
+	"github.com/shopspring/decimal"
+)
+
+// TickersResponse mirrors the CoinGecko GET /coins/{id}/tickers payload.
+// Fields we don't read are omitted (CG returns many — coin id, page, links).
+//
+// `Market.Logo` only appears with `include_exchange_logo=true` (CG Pro flag).
+type TickersResponse struct {
+	Tickers []TickerEntry `json:"tickers"`
+}
+
+type TickerEntry struct {
+	Base                   string                     `json:"base"`
+	Target                 string                     `json:"target"`
+	Market                 TickerMarket               `json:"market"`
+	Last                   *decimal.Decimal           `json:"last"`
+	Volume                 *decimal.Decimal           `json:"volume"`
+	ConvertedLast          map[string]decimal.Decimal `json:"converted_last"`
+	ConvertedVolume        map[string]decimal.Decimal `json:"converted_volume"`
+	TrustScore             string                     `json:"trust_score"`
+	BidAskSpreadPercentage *decimal.Decimal           `json:"bid_ask_spread_percentage"`
+	Timestamp              string                     `json:"timestamp"`      // RFC3339, optional
+	LastTradedAt           string                     `json:"last_traded_at"` // RFC3339, optional
+	LastFetchAt            string                     `json:"last_fetch_at"`  // RFC3339, optional
+	IsAnomaly              bool                       `json:"is_anomaly"`
+	IsStale                bool                       `json:"is_stale"`
+	TradeURL               string                     `json:"trade_url"`
+	TokenInfoURL           string                     `json:"token_info_url"`
+}
+
+type TickerMarket struct {
+	Name                string `json:"name"`
+	Identifier          string `json:"identifier"`
+	HasTradingIncentive bool   `json:"has_trading_incentive"`
+	Logo                string `json:"logo"` // CG Pro flag include_exchange_logo
+}
+
+// GetTickers fetches per-exchange tickers for `coinID` (e.g. "mavryk-network").
+// Pagination not implemented in v1 — single page is enough for MVRK in
+// foreseeable future. When MVRK is on >100 exchanges, page through `?page=1..`.
+func (c *Client) GetTickers(ctx context.Context, coinID string, includeLogo bool) (*TickersResponse, error) {
+	url := fmt.Sprintf("%s/coins/%s/tickers", c.baseURL, coinID)
+	if includeLogo {
+		url += "?include_exchange_logo=true"
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create tickers request: %w", err)
+	}
+	req.Header.Set("User-Agent", "mavryk-external-data/1.0")
+	if c.apiKey != "" {
+		req.Header.Set("x-cg-pro-api-key", c.apiKey)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute tickers request: %w", err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			c.log.Warn().Err(cerr).Msg("coingecko_tickers_body_close_error")
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("coingecko tickers returned status %d", resp.StatusCode)
+	}
+	var out TickersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode tickers: %w", err)
+	}
+	return &out, nil
+}
+
+// MapToTickers converts a CoinGecko tickers response into the domain shape used
+// by the storage repository.
+//
+// Skips rows where:
+//   - market.identifier is empty (no FK target)
+//   - last is missing or non-positive (can't compute change% or render in UI)
+//   - base symbol doesn't match the expected token (defensive — CG /tickers
+//     occasionally returns entries where the requested coin is the QUOTE, not
+//     the base; we don't want to store MVRK as a quote against another token)
+//
+// `now` is injected so the job's deterministic tick-time is what we record,
+// not a wall-clock spread across mapping (helps testing too). When CG provides
+// last_fetch_at we prefer that; otherwise last_traded_at; otherwise now.
+func MapToTickers(
+	resp *TickersResponse,
+	source prices.Source,
+	token prices.Token,
+	now time.Time,
+) ([]tickers.Exchange, []tickers.Ticker) {
+	if resp == nil || len(resp.Tickers) == 0 {
+		return nil, nil
+	}
+	tokenStr := strings.ToLower(strings.TrimSpace(string(token)))
+	now = now.UTC()
+
+	exMap := make(map[string]tickers.Exchange, len(resp.Tickers))
+	rows := make([]tickers.Ticker, 0, len(resp.Tickers))
+
+	for _, e := range resp.Tickers {
+		id := strings.TrimSpace(e.Market.Identifier)
+		if id == "" {
+			continue
+		}
+		base := strings.ToLower(strings.TrimSpace(e.Base))
+		// Match by symbol OR by token contract address (some CG entries report
+		// `base` as the on-chain token address rather than the symbol — accept
+		// either to maximize coverage).
+		if base != tokenStr && !strings.EqualFold(base, string(token)) {
+			// Skip rows where MVRK is the quote, not the base. We could
+			// support both directions later, but the UI semantics differ
+			// ("price of MVRK in X" vs "price of X in MVRK").
+			continue
+		}
+		if e.Last == nil || e.Last.IsZero() || e.Last.IsNegative() {
+			continue
+		}
+
+		ts := pickTickerTimestamp(e, now)
+
+		// Exchange — UPSERT row. Keep the latest name/logo we see, fall back
+		// to the identifier if name is missing.
+		name := strings.TrimSpace(e.Market.Name)
+		if name == "" {
+			name = id
+		}
+		exMap[id] = tickers.Exchange{
+			ID:                  id,
+			Name:                name,
+			LogoURL:             strings.TrimSpace(e.Market.Logo),
+			Kind:                tickers.ClassifyExchangeKind(id),
+			HasTradingIncentive: e.Market.HasTradingIncentive,
+			LastSeenAt:          now,
+		}
+
+		target := strings.ToLower(strings.TrimSpace(e.Target))
+		row := tickers.Ticker{
+			Token:        token,
+			Source:       source,
+			ExchangeID:   id,
+			TargetSymbol: target,
+			Timestamp:    ts,
+			LastPrice:    *e.Last,
+			VolumeBase:   e.Volume,
+			BidAskSpread: e.BidAskSpreadPercentage,
+			TrustScore:   strings.ToLower(strings.TrimSpace(e.TrustScore)),
+			IsAnomaly:    e.IsAnomaly || e.IsStale, // treat stale-from-CG as anomaly too
+			TradeURL:     strings.TrimSpace(e.TradeURL),
+		}
+		if tt := parseTickerTime(e.LastTradedAt); !tt.IsZero() {
+			row.LastTradedAt = tt
+		}
+		rows = append(rows, row)
+	}
+
+	exchanges := make([]tickers.Exchange, 0, len(exMap))
+	for _, e := range exMap {
+		exchanges = append(exchanges, e)
+	}
+	return exchanges, rows
+}
+
+// pickTickerTimestamp returns the freshest CG-provided timestamp, falling back
+// to `now`. last_fetch_at is the strongest signal (when CG observed the row);
+// last_traded_at is best-effort (depends on exchange API). `timestamp` (CG's
+// per-ticker observation time) is used if both fetch and trade are missing.
+func pickTickerTimestamp(e TickerEntry, now time.Time) time.Time {
+	if t := parseTickerTime(e.LastFetchAt); !t.IsZero() {
+		return t
+	}
+	if t := parseTickerTime(e.Timestamp); !t.IsZero() {
+		return t
+	}
+	if t := parseTickerTime(e.LastTradedAt); !t.IsZero() {
+		return t
+	}
+	return now
+}
+
+func parseTickerTime(s string) time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC()
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t.UTC()
+	}
+	return time.Time{}
+}

--- a/internal/core/infrastructure/interactions/coingecko/tickers_test.go
+++ b/internal/core/infrastructure/interactions/coingecko/tickers_test.go
@@ -1,0 +1,264 @@
+package coingecko
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"quotes/internal/core/domain/prices"
+	"quotes/internal/core/domain/tickers"
+
+	"github.com/shopspring/decimal"
+)
+
+func dec(s string) decimal.Decimal {
+	return decimal.RequireFromString(s)
+}
+
+func ptrDec(s string) *decimal.Decimal {
+	d := dec(s)
+	return &d
+}
+
+func TestMapToTickers_HappyPath(t *testing.T) {
+	now := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
+	resp := &TickersResponse{
+		Tickers: []TickerEntry{
+			{
+				Base:   "MVRK",
+				Target: "BTC",
+				Market: TickerMarket{
+					Name: "Binance", Identifier: "binance",
+					Logo: "https://example/binance.png", HasTradingIncentive: false,
+				},
+				Last:                   ptrDec("0.000021"),
+				Volume:                 ptrDec("1234567.89"),
+				BidAskSpreadPercentage: ptrDec("0.1"),
+				TrustScore:             "green",
+				TradeURL:               "https://binance.com/trade",
+				LastFetchAt:            "2026-05-29T11:55:00Z",
+				LastTradedAt:           "2026-05-29T11:54:00Z",
+			},
+		},
+	}
+	ex, rows := MapToTickers(resp, prices.SourceCoinGecko, prices.Token("mvrk"), now)
+	if len(ex) != 1 {
+		t.Fatalf("exchanges = %d, want 1", len(ex))
+	}
+	if ex[0].ID != "binance" || ex[0].Name != "Binance" || ex[0].LogoURL != "https://example/binance.png" {
+		t.Errorf("exchange: %+v", ex[0])
+	}
+	if ex[0].Kind != tickers.ExchangeKindCEX {
+		t.Errorf("kind = %q want cex", ex[0].Kind)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d want 1", len(rows))
+	}
+	r := rows[0]
+	if r.Token != "mvrk" || r.Source != prices.SourceCoinGecko || r.ExchangeID != "binance" || r.TargetSymbol != "btc" {
+		t.Errorf("row keys: %+v", r)
+	}
+	if !r.LastPrice.Equal(dec("0.000021")) {
+		t.Errorf("last_price = %s", r.LastPrice)
+	}
+	if r.VolumeBase == nil || !r.VolumeBase.Equal(dec("1234567.89")) {
+		t.Errorf("volume = %v", r.VolumeBase)
+	}
+	if r.Timestamp != time.Date(2026, 5, 29, 11, 55, 0, 0, time.UTC) {
+		t.Errorf("ts = %v want last_fetch_at", r.Timestamp)
+	}
+	if r.TrustScore != "green" || r.TradeURL != "https://binance.com/trade" {
+		t.Errorf("trust/trade: %s %s", r.TrustScore, r.TradeURL)
+	}
+}
+
+func TestMapToTickers_SkipMissingIdentifier(t *testing.T) {
+	resp := &TickersResponse{
+		Tickers: []TickerEntry{
+			{Base: "MVRK", Target: "USDT", Market: TickerMarket{Identifier: "", Name: "Phantom"}, Last: ptrDec("1")},
+			{Base: "MVRK", Target: "USDT", Market: TickerMarket{Identifier: "kraken", Name: "Kraken"}, Last: ptrDec("1")},
+		},
+	}
+	ex, rows := MapToTickers(resp, prices.SourceCoinGecko, "mvrk", time.Now())
+	if len(ex) != 1 || ex[0].ID != "kraken" {
+		t.Errorf("ex = %+v", ex)
+	}
+	if len(rows) != 1 || rows[0].ExchangeID != "kraken" {
+		t.Errorf("rows = %+v", rows)
+	}
+}
+
+func TestMapToTickers_SkipMissingLast(t *testing.T) {
+	resp := &TickersResponse{
+		Tickers: []TickerEntry{
+			{Base: "MVRK", Target: "USDT", Market: TickerMarket{Identifier: "a"}, Last: nil},
+			{Base: "MVRK", Target: "USDT", Market: TickerMarket{Identifier: "b"}, Last: ptrDec("0")},
+			{Base: "MVRK", Target: "USDT", Market: TickerMarket{Identifier: "c"}, Last: ptrDec("-1")},
+			{Base: "MVRK", Target: "USDT", Market: TickerMarket{Identifier: "d"}, Last: ptrDec("1")},
+		},
+	}
+	_, rows := MapToTickers(resp, prices.SourceCoinGecko, "mvrk", time.Now())
+	if len(rows) != 1 || rows[0].ExchangeID != "d" {
+		t.Errorf("rows = %+v", rows)
+	}
+}
+
+func TestMapToTickers_SkipWrongBaseToken(t *testing.T) {
+	resp := &TickersResponse{
+		Tickers: []TickerEntry{
+			{Base: "BTC", Target: "MVRK", Market: TickerMarket{Identifier: "x"}, Last: ptrDec("0.5")},
+			{Base: "mvrk", Target: "btc", Market: TickerMarket{Identifier: "y"}, Last: ptrDec("0.5")},
+		},
+	}
+	_, rows := MapToTickers(resp, prices.SourceCoinGecko, "mvrk", time.Now())
+	if len(rows) != 1 || rows[0].ExchangeID != "y" {
+		t.Errorf("rows = %+v", rows)
+	}
+}
+
+func TestMapToTickers_TimestampFallback(t *testing.T) {
+	now := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name      string
+		entry     TickerEntry
+		wantTS    time.Time
+		wantIsNow bool
+	}{
+		{
+			"last_fetch_at preferred",
+			TickerEntry{Base: "mvrk", Target: "btc", Market: TickerMarket{Identifier: "a"},
+				Last: ptrDec("1"), LastFetchAt: "2026-05-29T11:30:00Z", LastTradedAt: "2026-05-29T10:00:00Z", Timestamp: "2026-05-29T09:00:00Z"},
+			time.Date(2026, 5, 29, 11, 30, 0, 0, time.UTC), false,
+		},
+		{
+			"timestamp fallback",
+			TickerEntry{Base: "mvrk", Target: "btc", Market: TickerMarket{Identifier: "b"},
+				Last: ptrDec("1"), Timestamp: "2026-05-29T09:00:00Z"},
+			time.Date(2026, 5, 29, 9, 0, 0, 0, time.UTC), false,
+		},
+		{
+			"last_traded_at fallback",
+			TickerEntry{Base: "mvrk", Target: "btc", Market: TickerMarket{Identifier: "c"},
+				Last: ptrDec("1"), LastTradedAt: "2026-05-29T08:00:00Z"},
+			time.Date(2026, 5, 29, 8, 0, 0, 0, time.UTC), false,
+		},
+		{
+			"all empty → now",
+			TickerEntry{Base: "mvrk", Target: "btc", Market: TickerMarket{Identifier: "d"}, Last: ptrDec("1")},
+			now, true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resp := &TickersResponse{Tickers: []TickerEntry{c.entry}}
+			_, rows := MapToTickers(resp, prices.SourceCoinGecko, "mvrk", now)
+			if len(rows) != 1 {
+				t.Fatalf("rows = %d", len(rows))
+			}
+			if !rows[0].Timestamp.Equal(c.wantTS) {
+				t.Errorf("ts = %v want %v", rows[0].Timestamp, c.wantTS)
+			}
+		})
+	}
+}
+
+func TestMapToTickers_EmptyAndNil(t *testing.T) {
+	if ex, rows := MapToTickers(nil, prices.SourceCoinGecko, "mvrk", time.Now()); ex != nil || rows != nil {
+		t.Errorf("nil resp: ex=%v rows=%v", ex, rows)
+	}
+	if ex, rows := MapToTickers(&TickersResponse{}, prices.SourceCoinGecko, "mvrk", time.Now()); ex != nil || rows != nil {
+		t.Errorf("empty resp: ex=%v rows=%v", ex, rows)
+	}
+}
+
+func TestMapToTickers_StaleFlagPromotesAnomaly(t *testing.T) {
+	resp := &TickersResponse{Tickers: []TickerEntry{
+		{Base: "mvrk", Target: "btc", Market: TickerMarket{Identifier: "x"}, Last: ptrDec("1"), IsStale: true},
+	}}
+	_, rows := MapToTickers(resp, prices.SourceCoinGecko, "mvrk", time.Now())
+	if len(rows) != 1 || !rows[0].IsAnomaly {
+		t.Errorf("is_stale should promote is_anomaly: rows=%+v", rows)
+	}
+}
+
+func TestMapToTickers_ExchangeDeduped(t *testing.T) {
+	// MVRK/BTC + MVRK/USDT on Binance — same exchange row, two ticker rows.
+	resp := &TickersResponse{Tickers: []TickerEntry{
+		{Base: "mvrk", Target: "btc", Market: TickerMarket{Identifier: "binance", Name: "Binance"}, Last: ptrDec("1")},
+		{Base: "mvrk", Target: "usdt", Market: TickerMarket{Identifier: "binance", Name: "Binance"}, Last: ptrDec("2")},
+	}}
+	ex, rows := MapToTickers(resp, prices.SourceCoinGecko, "mvrk", time.Now())
+	if len(ex) != 1 {
+		t.Errorf("exchanges = %d want 1 (deduped by id)", len(ex))
+	}
+	if len(rows) != 2 {
+		t.Errorf("rows = %d want 2", len(rows))
+	}
+	// Sanity: both rows reference the same exchange id.
+	if rows[0].ExchangeID != "binance" || rows[1].ExchangeID != "binance" {
+		t.Errorf("rows: %+v", rows)
+	}
+}
+
+func TestMapToTickers_DEXClassification(t *testing.T) {
+	resp := &TickersResponse{Tickers: []TickerEntry{
+		{Base: "mvrk", Target: "usdt", Market: TickerMarket{Identifier: "uniswap_v3", Name: "Uniswap V3"}, Last: ptrDec("1")},
+	}}
+	ex, _ := MapToTickers(resp, prices.SourceCoinGecko, "mvrk", time.Now())
+	if len(ex) != 1 || ex[0].Kind != tickers.ExchangeKindDEX {
+		t.Errorf("dex classification failed: %+v", ex)
+	}
+}
+
+func TestMapToTickers_NameFallbackToIdentifier(t *testing.T) {
+	resp := &TickersResponse{Tickers: []TickerEntry{
+		{Base: "mvrk", Target: "usdt", Market: TickerMarket{Identifier: "weird_dex", Name: ""}, Last: ptrDec("1")},
+	}}
+	ex, _ := MapToTickers(resp, prices.SourceCoinGecko, "mvrk", time.Now())
+	if len(ex) != 1 || ex[0].Name != "weird_dex" {
+		t.Errorf("name fallback: %+v", ex)
+	}
+}
+
+// TestTickerEntry_JSONDecode pins the JSON shape against CG's actual response.
+func TestTickerEntry_JSONDecode(t *testing.T) {
+	body := `{
+		"tickers": [{
+			"base":"MVRK","target":"BTC",
+			"market":{"name":"Binance","identifier":"binance","has_trading_incentive":false,"logo":"x.png"},
+			"last": "0.000021",
+			"volume": "1234567.89",
+			"converted_last": {"usd": "0.085"},
+			"converted_volume": {"usd": "22000"},
+			"trust_score":"green",
+			"bid_ask_spread_percentage":"0.1",
+			"timestamp":"2026-05-29T11:00:00Z",
+			"last_traded_at":"2026-05-29T11:00:00Z",
+			"last_fetch_at":"2026-05-29T11:05:00Z",
+			"is_anomaly": false,
+			"is_stale": false,
+			"trade_url":"https://binance.com/trade/MVRK_BTC"
+		}]
+	}`
+	var resp TickersResponse
+	if err := json.NewDecoder(strings.NewReader(body)).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Tickers) != 1 {
+		t.Fatalf("tickers = %d", len(resp.Tickers))
+	}
+	e := resp.Tickers[0]
+	if e.Market.Identifier != "binance" || e.Market.Logo != "x.png" {
+		t.Errorf("market: %+v", e.Market)
+	}
+	if e.Last == nil || !e.Last.Equal(dec("0.000021")) {
+		t.Errorf("last = %v", e.Last)
+	}
+	if v, ok := e.ConvertedLast["usd"]; !ok || !v.Equal(dec("0.085")) {
+		t.Errorf("converted_last[usd] = %v ok=%v", v, ok)
+	}
+	if e.BidAskSpreadPercentage == nil || !e.BidAskSpreadPercentage.Equal(dec("0.1")) {
+		t.Errorf("bid_ask_spread = %v", e.BidAskSpreadPercentage)
+	}
+}

--- a/internal/core/infrastructure/jobs/coingecko_tickers.go
+++ b/internal/core/infrastructure/jobs/coingecko_tickers.go
@@ -1,0 +1,146 @@
+package jobs
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"quotes/internal/config"
+	apitickers "quotes/internal/core/application/tickers"
+	"quotes/internal/core/domain/prices"
+	"quotes/internal/core/infrastructure/interactions/coingecko"
+	"quotes/internal/logging"
+	"quotes/internal/metrics"
+
+	"github.com/rs/zerolog"
+)
+
+// CoinGeckoTickersJob polls /coins/{token}/tickers on a fixed cadence (default
+// 5min) and writes the snapshot into token_tickers via the application
+// Repository. Single-token in v1 (MVRK); follow-up TODOS-2 brings DEX phase.
+//
+// The job is a thin orchestrator: HTTP fetch → mapper → repository.SaveSnapshot.
+// All resilience (rate-limit, retry, CB, max-bytes) lives in the CG client's
+// transport stack — same one the live FT job uses.
+type CoinGeckoTickersJob struct {
+	cfg    *config.Config
+	repo   apitickers.Repository
+	client *coingecko.Client
+	logger *zerolog.Logger
+
+	tokenSymbol string
+	coinID      string
+	source      prices.Source
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+}
+
+// NewCoinGeckoTickersJob constructs the job. The CG client gets a separate
+// timeout because /tickers payloads can be larger than /market_chart/range —
+// surfaced via cfg.Tickers.HTTPTimeout.
+func NewCoinGeckoTickersJob(cfg *config.Config, repo apitickers.Repository, log *zerolog.Logger) *CoinGeckoTickersJob {
+	if log == nil {
+		nop := zerolog.Nop()
+		log = &nop
+	}
+	logger := logging.WithComponent(log, "coingecko_tickers_job")
+	timeout := cfg.Tickers.HTTPTimeout.D()
+	client := coingecko.NewClient(cfg.CoinGecko, &cfg.API, timeout, logger)
+	return &CoinGeckoTickersJob{
+		cfg:         cfg,
+		repo:        repo,
+		client:      client,
+		logger:      logger,
+		tokenSymbol: cfg.Tickers.TokenSymbol,
+		source:      prices.SourceCoinGecko,
+		stopCh:      make(chan struct{}),
+	}
+}
+
+// Start runs the job in its own goroutine. Returns immediately. Resolves the
+// CoinGecko coin id from the runtime token registry — if the token isn't
+// registered, the job logs once and exits cleanly (no panics in main).
+func (j *CoinGeckoTickersJob) Start(ctx context.Context) {
+	if !j.cfg.Tickers.Enabled {
+		j.logger.Info().Msg("tickers_job_disabled_by_config")
+		return
+	}
+	if j.tokenSymbol == "" {
+		j.logger.Warn().Msg("tickers_job_no_token_configured")
+		return
+	}
+	tok, err := prices.NewToken(j.tokenSymbol)
+	if err != nil {
+		j.logger.Error().Err(err).Str("token", j.tokenSymbol).Msg("tickers_job_token_not_in_registry")
+		return
+	}
+	info, ok := prices.LookupToken(tok)
+	if !ok || info.CoinGeckoID == "" {
+		j.logger.Error().Str("token", string(tok)).Msg("tickers_job_no_cg_id_for_token")
+		return
+	}
+	j.coinID = info.CoinGeckoID
+
+	interval := time.Duration(j.cfg.Tickers.IntervalSeconds) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Minute
+	}
+
+	safeGo(&j.wg, j.logger, "tickers:"+j.tokenSymbol, func() {
+		runTickerLoop(ctx, j.stopCh, interval, 0, j.logger, func(c context.Context) {
+			j.collectOnce(c, tok)
+		})
+	})
+}
+
+// Stop signals the goroutine and waits. Idempotent.
+func (j *CoinGeckoTickersJob) Stop() {
+	j.stopOnce.Do(func() { close(j.stopCh) })
+	j.wg.Wait()
+}
+
+// collectOnce fetches the live tickers payload and writes the result.
+func (j *CoinGeckoTickersJob) collectOnce(ctx context.Context, token prices.Token) {
+	if err := ctx.Err(); err != nil {
+		return
+	}
+	logger := j.logger.With().Str("token", string(token)).Logger()
+
+	start := time.Now()
+	defer func() {
+		metrics.JobTickDurationSeconds.
+			WithLabelValues("tickers", string(j.source), string(token)).
+			Observe(time.Since(start).Seconds())
+	}()
+
+	resp, err := j.client.GetTickers(ctx, j.coinID, j.cfg.Tickers.IncludeExchangeLogo)
+	if err != nil {
+		metrics.JobErrorsTotal.WithLabelValues("tickers", string(j.source), string(token), "fetch").Inc()
+		logger.Error().Err(err).Msg("tickers_fetch_failed")
+		return
+	}
+
+	now := time.Now().UTC()
+	exchanges, rows := coingecko.MapToTickers(resp, j.source, token, now)
+	if len(rows) == 0 {
+		logger.Debug().Msg("tickers_no_rows_after_mapping")
+		return
+	}
+
+	n, err := j.repo.SaveSnapshot(ctx, exchanges, rows)
+	if err != nil {
+		metrics.JobErrorsTotal.WithLabelValues("tickers", string(j.source), string(token), "save").Inc()
+		logger.Error().Err(err).Msg("tickers_save_failed")
+		return
+	}
+	metrics.JobRowsAffectedTotal.
+		WithLabelValues("tickers", string(j.source), string(token)).
+		Add(float64(n))
+	logger.Info().
+		Int("exchanges", len(exchanges)).
+		Int("rows", len(rows)).
+		Int64("rows_affected", n).
+		Msg("tickers_collected")
+}

--- a/internal/core/infrastructure/storage/entities/ticker.go
+++ b/internal/core/infrastructure/storage/entities/ticker.go
@@ -1,0 +1,46 @@
+package entities
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// ExchangeEntity maps to the `exchanges` lookup table.
+//
+// `ID` is the CoinGecko market.identifier (e.g. "binance"). `Kind` is derived
+// in code via tickers.ClassifyExchangeKind; CHECK constraint in 0012 keeps it
+// to 'cex' / 'dex'. LastSeenAt is bumped on every job tick via UPSERT —
+// useful operationally for spotting exchanges that delisted MVRK.
+type ExchangeEntity struct {
+	ID                  string    `gorm:"primaryKey;column:id"`
+	Name                string    `gorm:"column:name;not null"`
+	LogoURL             *string   `gorm:"column:logo_url"`
+	Kind                string    `gorm:"column:kind;not null"`
+	HasTradingIncentive bool      `gorm:"column:has_trading_incentive;not null"`
+	LastSeenAt          time.Time `gorm:"column:last_seen_at;not null"`
+}
+
+func (ExchangeEntity) TableName() string { return "exchanges" }
+
+// TokenTickerEntity is one row in the `token_tickers` hypertable.
+//
+// Composite PK (TokenSymbol, SourceCode, ExchangeID, TargetSymbol, Timestamp).
+// Native units only — all FX conversion happens read-side via PriceConverter
+// (ADR-0013). No `is_stale` column: derived from ts at read time.
+type TokenTickerEntity struct {
+	TokenSymbol     string           `gorm:"primaryKey;column:token_symbol;not null"`
+	SourceCode      string           `gorm:"primaryKey;column:source_code;not null"`
+	ExchangeID      string           `gorm:"primaryKey;column:exchange_id;not null"`
+	TargetSymbol    string           `gorm:"primaryKey;column:target_symbol;not null"`
+	Timestamp       time.Time        `gorm:"primaryKey;column:ts;not null"`
+	LastPrice       decimal.Decimal  `gorm:"column:last_price;type:numeric(38,18);not null"`
+	VolumeBase      *decimal.Decimal `gorm:"column:volume_24h_base;type:numeric(38,18)"`
+	BidAskSpreadPct *decimal.Decimal `gorm:"column:bid_ask_spread_pct;type:numeric(20,10)"`
+	TrustScore      *string          `gorm:"column:trust_score"`
+	IsAnomaly       bool             `gorm:"column:is_anomaly;not null"`
+	TradeURL        *string          `gorm:"column:trade_url"`
+	LastTradedAt    *time.Time       `gorm:"column:last_traded_at"`
+}
+
+func (TokenTickerEntity) TableName() string { return "token_tickers" }

--- a/internal/core/infrastructure/storage/repositories/ticker_repository.go
+++ b/internal/core/infrastructure/storage/repositories/ticker_repository.go
@@ -1,0 +1,434 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	apitickers "quotes/internal/core/application/tickers"
+	"quotes/internal/core/domain/tickers"
+	"quotes/internal/core/infrastructure/storage/entities"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// TickerRepository serves long-format per-exchange ticker data.
+//
+// Two physical tables back this:
+//   - `exchanges`     — small lookup, UPSERT on every job tick.
+//   - `token_tickers` — hypertable, INSERT ON CONFLICT DO NOTHING (idempotent
+//     under repeat ticks at the same `ts`).
+//
+// SaveSnapshot writes BOTH inside one transaction — the FK invariant on
+// `token_tickers.exchange_id` requires exchanges to land before any tickers
+// referencing a brand-new exchange.
+type TickerRepository struct {
+	db        *gorm.DB
+	batchSize int
+}
+
+func NewTickerRepository(db *gorm.DB) *TickerRepository {
+	return &TickerRepository{db: db, batchSize: DefaultBatchSize}
+}
+
+// WithBatchSize sets the CreateInBatches chunk size (mutates in place;
+// returned for chainability). n <= 0 falls back to DefaultBatchSize.
+func (r *TickerRepository) WithBatchSize(n int) *TickerRepository {
+	if n > 0 {
+		r.batchSize = n
+	}
+	return r
+}
+
+func exchangeUpsert() clause.OnConflict {
+	return clause.OnConflict{
+		Columns: []clause.Column{{Name: "id"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"name", "logo_url", "kind", "has_trading_incentive", "last_seen_at",
+		}),
+	}
+}
+
+func tickerInsert() clause.OnConflict {
+	// Idempotent re-ingest under the 5-min cadence — if the upstream returns
+	// the same row twice (we never lower granularity below the CG cadence),
+	// keep the existing row. Numbers don't get rewritten on conflict.
+	return clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "token_symbol"}, {Name: "source_code"},
+			{Name: "exchange_id"}, {Name: "target_symbol"}, {Name: "ts"},
+		},
+		DoNothing: true,
+	}
+}
+
+// SaveSnapshot writes exchanges (UPSERT) and tickers (INSERT) in one tx.
+func (r *TickerRepository) SaveSnapshot(
+	ctx context.Context,
+	exchanges []tickers.Exchange,
+	rows []tickers.Ticker,
+) (int64, error) {
+	if len(exchanges) == 0 && len(rows) == 0 {
+		return 0, nil
+	}
+	var total int64
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if len(exchanges) > 0 {
+			exRows := exchangesToEntities(exchanges)
+			res := tx.Clauses(exchangeUpsert()).CreateInBatches(exRows, r.batchSize)
+			if res.Error != nil {
+				return fmt.Errorf("upsert exchanges: %w", res.Error)
+			}
+			// exchanges upsert count is not part of the ticker delta — keep total
+			// pinned to ticker inserts for cache-invalidation accounting.
+		}
+		if len(rows) > 0 {
+			tRows := tickersToEntities(rows)
+			res := tx.Clauses(tickerInsert()).CreateInBatches(tRows, r.batchSize)
+			if res.Error != nil {
+				return fmt.Errorf("insert token_tickers: %w", res.Error)
+			}
+			total = res.RowsAffected
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+// LatestSnapshot returns one row per (exchange, target) for `token`, freshest
+// first, with 1D change% joined in via LATERAL against the same table.
+//
+// Query shape:
+//
+//	WITH latest AS (
+//	    SELECT DISTINCT ON (exchange_id, target_symbol) *
+//	      FROM token_tickers
+//	     WHERE token_symbol = ? AND source_code = ?
+//	     [AND ts >= now - stale_after]
+//	     ORDER BY exchange_id, target_symbol, ts DESC
+//	)
+//	SELECT latest.*, ago.last_price AS price_24h_ago,
+//	       exchanges.name AS exchange_name, exchanges.logo_url, exchanges.kind
+//	  FROM latest
+//	  JOIN exchanges ON exchanges.id = latest.exchange_id
+//	  LEFT JOIN LATERAL (
+//	     SELECT last_price FROM token_tickers
+//	      WHERE token_symbol = latest.token_symbol
+//	        AND source_code  = latest.source_code
+//	        AND exchange_id  = latest.exchange_id
+//	        AND target_symbol = latest.target_symbol
+//	        AND ts <= latest.ts - INTERVAL '24 hours'
+//	      ORDER BY ts DESC LIMIT 1
+//	  ) ago ON true
+//	  ORDER BY latest.last_price * COALESCE(latest.volume_24h_base, 0) DESC;
+//
+// All filters parameterised. is_stale derived in Go from the returned `ts`
+// against the caller's StaleAfter window.
+func (r *TickerRepository) LatestSnapshot(
+	ctx context.Context,
+	q apitickers.LatestQuery,
+) (tickers.Snapshot, error) {
+	stalePredicate := ""
+	args := []any{string(q.Token), string(q.Source)}
+	if !q.IncludeStale && q.StaleAfter > 0 {
+		stalePredicate = " AND ts >= ?"
+		args = append(args, time.Now().UTC().Add(-q.StaleAfter))
+	}
+
+	sql := `
+WITH latest AS (
+    SELECT DISTINCT ON (exchange_id, target_symbol)
+           token_symbol, source_code, exchange_id, target_symbol, ts,
+           last_price, volume_24h_base, bid_ask_spread_pct, trust_score,
+           is_anomaly, trade_url, last_traded_at
+      FROM token_tickers
+     WHERE token_symbol = ? AND source_code = ?` + stalePredicate + `
+     ORDER BY exchange_id, target_symbol, ts DESC
+)
+SELECT
+    latest.exchange_id   AS exchange_id,
+    latest.target_symbol AS target_symbol,
+    latest.ts            AS ts,
+    latest.last_price    AS last_price,
+    latest.volume_24h_base AS volume_24h_base,
+    latest.bid_ask_spread_pct AS bid_ask_spread_pct,
+    latest.trust_score   AS trust_score,
+    latest.is_anomaly    AS is_anomaly,
+    latest.trade_url     AS trade_url,
+    latest.last_traded_at AS last_traded_at,
+    ago.last_price       AS price_24h_ago,
+    e.name               AS exchange_name,
+    e.logo_url           AS exchange_logo,
+    e.kind               AS exchange_kind,
+    e.has_trading_incentive AS exchange_has_trading_incentive
+  FROM latest
+  JOIN exchanges e ON e.id = latest.exchange_id
+  LEFT JOIN LATERAL (
+      SELECT last_price FROM token_tickers
+       WHERE token_symbol  = latest.token_symbol
+         AND source_code   = latest.source_code
+         AND exchange_id   = latest.exchange_id
+         AND target_symbol = latest.target_symbol
+         AND ts <= latest.ts - INTERVAL '24 hours'
+       ORDER BY ts DESC LIMIT 1
+  ) ago ON TRUE
+  ORDER BY (latest.last_price * COALESCE(latest.volume_24h_base, 0)) DESC NULLS LAST,
+           latest.exchange_id ASC, latest.target_symbol ASC`
+
+	type row struct {
+		ExchangeID                  string           `gorm:"column:exchange_id"`
+		TargetSymbol                string           `gorm:"column:target_symbol"`
+		Timestamp                   time.Time        `gorm:"column:ts"`
+		LastPrice                   decimal.Decimal  `gorm:"column:last_price"`
+		Volume24hBase               *decimal.Decimal `gorm:"column:volume_24h_base"`
+		BidAskSpreadPct             *decimal.Decimal `gorm:"column:bid_ask_spread_pct"`
+		TrustScore                  *string          `gorm:"column:trust_score"`
+		IsAnomaly                   bool             `gorm:"column:is_anomaly"`
+		TradeURL                    *string          `gorm:"column:trade_url"`
+		LastTradedAt                *time.Time       `gorm:"column:last_traded_at"`
+		Price24hAgo                 *decimal.Decimal `gorm:"column:price_24h_ago"`
+		ExchangeName                string           `gorm:"column:exchange_name"`
+		ExchangeLogo                *string          `gorm:"column:exchange_logo"`
+		ExchangeKind                string           `gorm:"column:exchange_kind"`
+		ExchangeHasTradingIncentive bool             `gorm:"column:exchange_has_trading_incentive"`
+	}
+	var rows []row
+	if err := r.db.WithContext(ctx).Raw(sql, args...).Scan(&rows).Error; err != nil {
+		return tickers.Snapshot{}, fmt.Errorf("query latest token_tickers: %w", err)
+	}
+
+	now := time.Now().UTC()
+	var newest time.Time
+	out := tickers.Snapshot{
+		Token:  q.Token,
+		Source: q.Source,
+		Rows:   make([]tickers.SnapshotRow, 0, len(rows)),
+	}
+	for _, r := range rows {
+		row := tickers.SnapshotRow{
+			Exchange: tickers.Exchange{
+				ID:                  r.ExchangeID,
+				Name:                r.ExchangeName,
+				LogoURL:             derefString(r.ExchangeLogo),
+				Kind:                tickers.ExchangeKind(r.ExchangeKind),
+				HasTradingIncentive: r.ExchangeHasTradingIncentive,
+			},
+			TargetSymbol: r.TargetSymbol,
+			Timestamp:    r.Timestamp.UTC(),
+			LastPrice:    r.LastPrice,
+			VolumeBase:   r.Volume24hBase,
+			BidAskSpread: r.BidAskSpreadPct,
+			TrustScore:   derefString(r.TrustScore),
+			IsAnomaly:    r.IsAnomaly,
+			TradeURL:     derefString(r.TradeURL),
+			Change24hPct: percentChange(r.LastPrice, r.Price24hAgo),
+		}
+		if q.StaleAfter > 0 {
+			row.IsStale = now.Sub(r.Timestamp) > q.StaleAfter
+		}
+		if r.Timestamp.After(newest) {
+			newest = r.Timestamp.UTC()
+		}
+		out.Rows = append(out.Rows, row)
+	}
+	out.Timestamp = newest
+	return out, nil
+}
+
+// VolumeDistribution aggregates the freshest-per-(exchange,target) volume
+// row into either an exchange grouping or a target-symbol grouping. Stale
+// rows always excluded — pie charts about current state, never history.
+//
+// Two-stage SQL: the inner DISTINCT ON keeps "freshest row per pair", the
+// outer GROUP BY sums those into the requested dimension. SUM is over
+// snapshot values of `volume_24h_base` (CG returns a rolling 24h total per
+// row, never a delta — so the outer aggregation is one number per pair, not
+// across time).
+func (r *TickerRepository) VolumeDistribution(
+	ctx context.Context,
+	q apitickers.DistributionQuery,
+) (tickers.Distribution, error) {
+	stalePredicate := ""
+	args := []any{string(q.Token), string(q.Source)}
+	if q.StaleAfter > 0 {
+		stalePredicate = " AND ts >= ?"
+		args = append(args, time.Now().UTC().Add(-q.StaleAfter))
+	}
+
+	var groupExpr, selectKey string
+	switch q.GroupBy {
+	case tickers.GroupByExchange:
+		groupExpr = "latest.exchange_id"
+		selectKey = `latest.exchange_id AS group_key, e.name AS exchange_name,
+		             e.logo_url AS exchange_logo, e.kind AS exchange_kind,
+		             '' AS target_symbol`
+	case tickers.GroupByTarget:
+		groupExpr = "latest.target_symbol"
+		selectKey = `latest.target_symbol AS group_key, '' AS exchange_name,
+		             NULL::text AS exchange_logo, '' AS exchange_kind,
+		             latest.target_symbol AS target_symbol`
+	default:
+		return tickers.Distribution{}, fmt.Errorf("unsupported group_by: %q", q.GroupBy)
+	}
+
+	// JOIN exchanges only needed for GroupBy=exchange (logo/name); for
+	// GroupBy=target it's still in the inner CTE for the FROM clause, but
+	// the outer SELECT doesn't read from it. Cheap because the lookup is tiny.
+	join := "JOIN exchanges e ON e.id = latest.exchange_id"
+	sql := `
+WITH latest AS (
+    SELECT DISTINCT ON (exchange_id, target_symbol)
+           exchange_id, target_symbol, ts, volume_24h_base
+      FROM token_tickers
+     WHERE token_symbol = ? AND source_code = ?` + stalePredicate + `
+     ORDER BY exchange_id, target_symbol, ts DESC
+)
+SELECT ` + selectKey + `,
+       COALESCE(SUM(latest.volume_24h_base), 0)::numeric(38,18) AS volume_base
+  FROM latest
+  ` + join + `
+ GROUP BY ` + groupExpr + `, exchange_name, exchange_logo, exchange_kind
+ ORDER BY volume_base DESC, group_key ASC`
+
+	type row struct {
+		GroupKey     string          `gorm:"column:group_key"`
+		ExchangeName string          `gorm:"column:exchange_name"`
+		ExchangeLogo *string         `gorm:"column:exchange_logo"`
+		ExchangeKind string          `gorm:"column:exchange_kind"`
+		TargetSymbol string          `gorm:"column:target_symbol"`
+		VolumeBase   decimal.Decimal `gorm:"column:volume_base"`
+	}
+	var rows []row
+	if err := r.db.WithContext(ctx).Raw(sql, args...).Scan(&rows).Error; err != nil {
+		return tickers.Distribution{}, fmt.Errorf("query distribution: %w", err)
+	}
+
+	total := decimal.Zero
+	for _, r := range rows {
+		total = total.Add(r.VolumeBase)
+	}
+
+	out := tickers.Distribution{
+		Token:     q.Token,
+		Source:    q.Source,
+		Timestamp: time.Now().UTC(),
+		GroupBy:   q.GroupBy,
+		Total:     total,
+		Rows:      make([]tickers.DistributionRow, 0, len(rows)),
+	}
+	if total.IsZero() {
+		// No useful volume to bucket; return empty.
+		return out, nil
+	}
+	hundred := decimal.NewFromInt(100)
+	for _, r := range rows {
+		if r.VolumeBase.IsZero() {
+			continue
+		}
+		share := r.VolumeBase.DivRound(total, 8).Mul(hundred).Round(6)
+		dr := tickers.DistributionRow{
+			VolumeBase: r.VolumeBase,
+			SharePct:   share,
+		}
+		if q.GroupBy == tickers.GroupByExchange {
+			dr.Exchange = tickers.Exchange{
+				ID:      r.GroupKey,
+				Name:    r.ExchangeName,
+				LogoURL: derefString(r.ExchangeLogo),
+				Kind:    tickers.ExchangeKind(r.ExchangeKind),
+			}
+		} else {
+			dr.TargetSymbol = r.TargetSymbol
+		}
+		out.Rows = append(out.Rows, dr)
+	}
+	return out, nil
+}
+
+// Compile-time: TickerRepository satisfies the application interface.
+var _ apitickers.Repository = (*TickerRepository)(nil)
+
+// --- helpers ---
+
+func exchangesToEntities(in []tickers.Exchange) []entities.ExchangeEntity {
+	out := make([]entities.ExchangeEntity, len(in))
+	for i, e := range in {
+		var logo *string
+		if s := strings.TrimSpace(e.LogoURL); s != "" {
+			ls := s
+			logo = &ls
+		}
+		kind := string(e.Kind)
+		if kind == "" {
+			kind = string(tickers.ExchangeKindCEX)
+		}
+		seen := e.LastSeenAt
+		if seen.IsZero() {
+			seen = time.Now().UTC()
+		}
+		out[i] = entities.ExchangeEntity{
+			ID:                  e.ID,
+			Name:                e.Name,
+			LogoURL:             logo,
+			Kind:                kind,
+			HasTradingIncentive: e.HasTradingIncentive,
+			LastSeenAt:          seen.UTC(),
+		}
+	}
+	return out
+}
+
+func tickersToEntities(in []tickers.Ticker) []entities.TokenTickerEntity {
+	out := make([]entities.TokenTickerEntity, len(in))
+	for i, t := range in {
+		ent := entities.TokenTickerEntity{
+			TokenSymbol:     string(t.Token),
+			SourceCode:      string(t.Source),
+			ExchangeID:      t.ExchangeID,
+			TargetSymbol:    strings.ToLower(strings.TrimSpace(t.TargetSymbol)),
+			Timestamp:       t.Timestamp.UTC(),
+			LastPrice:       t.LastPrice,
+			VolumeBase:      t.VolumeBase,
+			BidAskSpreadPct: t.BidAskSpread,
+			IsAnomaly:       t.IsAnomaly,
+		}
+		if s := strings.TrimSpace(t.TrustScore); s != "" {
+			ts := s
+			ent.TrustScore = &ts
+		}
+		if s := strings.TrimSpace(t.TradeURL); s != "" {
+			ts := s
+			ent.TradeURL = &ts
+		}
+		if !t.LastTradedAt.IsZero() {
+			lt := t.LastTradedAt.UTC()
+			ent.LastTradedAt = &lt
+		}
+		out[i] = ent
+	}
+	return out
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// percentChange returns ((now - past) / past * 100) rounded to 6dp. Returns
+// nil when past is missing or zero (no meaningful percentage).
+func percentChange(now decimal.Decimal, past *decimal.Decimal) *decimal.Decimal {
+	if past == nil || past.IsZero() {
+		return nil
+	}
+	delta := now.Sub(*past)
+	pct := delta.DivRound(*past, 10).Mul(decimal.NewFromInt(100)).Round(6)
+	return &pct
+}

--- a/migrations/0012_exchanges.sql
+++ b/migrations/0012_exchanges.sql
@@ -1,0 +1,24 @@
+-- 0012_exchanges.sql
+-- Lookup table for crypto exchanges that report MVRK (and future tokens)
+-- tickers. Populated by the CoinGecko tickers job — UPSERT semantics keep
+-- name/logo/kind fresh as CG amends them.
+--
+-- `id` matches CoinGecko's market.identifier (e.g. "binance", "kraken").
+-- `kind` is derived in code (domain/tickers/exchange_kind.go) since CG /tickers
+-- does not tag CEX vs DEX. Default 'cex' is the safe fallback.
+--
+-- FK target for token_tickers.exchange_id. Light row count (low hundreds at
+-- most), so plain B-tree on the PK is enough — no Timescale needed here.
+
+CREATE TABLE IF NOT EXISTS exchanges (
+    id                    text PRIMARY KEY,
+    name                  text NOT NULL,
+    logo_url              text,
+    kind                  text NOT NULL DEFAULT 'cex'
+                          CHECK (kind IN ('cex','dex')),
+    has_trading_incentive boolean NOT NULL DEFAULT FALSE,
+    last_seen_at          timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_exchanges_last_seen
+    ON exchanges (last_seen_at DESC);

--- a/migrations/0013_token_tickers.sql
+++ b/migrations/0013_token_tickers.sql
@@ -1,0 +1,54 @@
+-- 0013_token_tickers.sql
+-- Long-format hypertable for per-exchange ticker data (CoinGecko /coins/{id}/tickers).
+-- One row = one observation at (token, source, exchange, target_symbol, ts).
+--
+-- Native units only: `last_price` is in `target_symbol` units (e.g. for MVRK/BTC
+-- it's BTC per MVRK), `volume_24h_base` is in the *token* (e.g. count of MVRK).
+-- Multi-currency rendering (?in=usd,eur,...) happens read-side via the
+-- PriceConverter (ADR-0013). No stored converted_*_usd columns.
+--
+-- Stale-ness is derived at read time from `ts < now - server.ticker_stale_after`
+-- (default 1h) — not stored.
+--
+-- The (token, exchange, target, ts DESC) index is the hot path for
+--   * /v1/tickers/:token/latest    — DISTINCT ON (exchange,target) ORDER BY ts DESC
+--   * 1D change LATERAL join       — find freshest row with ts <= now - 24h
+-- Both are O(log n) seeks on a per-pair leaf.
+
+CREATE TABLE IF NOT EXISTS token_tickers (
+    token_symbol         text           NOT NULL REFERENCES tokens(symbol),
+    source_code          text           NOT NULL REFERENCES sources(code),
+    exchange_id          text           NOT NULL REFERENCES exchanges(id),
+    target_symbol        text           NOT NULL,
+    ts                   timestamptz    NOT NULL,
+    last_price           numeric(38,18) NOT NULL,
+    volume_24h_base      numeric(38,18),
+    bid_ask_spread_pct   numeric(20,10),
+    trust_score          text,
+    is_anomaly           boolean        NOT NULL DEFAULT FALSE,
+    trade_url            text,
+    last_traded_at       timestamptz,
+    PRIMARY KEY (token_symbol, source_code, exchange_id, target_symbol, ts)
+);
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb') THEN
+        PERFORM create_hypertable(
+            'token_tickers',
+            'ts',
+            chunk_time_interval => INTERVAL '7 days',
+            if_not_exists       => TRUE
+        );
+    ELSE
+        RAISE NOTICE 'TimescaleDB not installed; token_tickers stays a regular table';
+    END IF;
+END $$ LANGUAGE plpgsql;
+
+-- Latest per (exchange, target) is the dominant read pattern.
+CREATE INDEX IF NOT EXISTS idx_token_tickers_latest
+    ON token_tickers (token_symbol, exchange_id, target_symbol, ts DESC);
+
+-- Token-wide scans (window queries via TODOS-3 once history endpoint lands).
+CREATE INDEX IF NOT EXISTS idx_token_tickers_token_ts
+    ON token_tickers (token_symbol, ts DESC);

--- a/migrations/0014_compression_retention_tickers.sql
+++ b/migrations/0014_compression_retention_tickers.sql
@@ -1,0 +1,33 @@
+-- 0014_compression_retention_tickers.sql
+-- Compression + retention for token_tickers.
+--
+-- Compress after 7d, retain raw 90d. Shorter than token_prices (14d / 2y)
+-- because (a) tickers churn faster — every 5min × N exchange-target pairs,
+-- and (b) we have no validated retro-analytics use beyond 90 days. Adjust
+-- when a real consumer asks for longer-window joins.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb') THEN
+        RAISE NOTICE 'TimescaleDB not installed; skipping compression/retention on token_tickers';
+        RETURN;
+    END IF;
+
+    EXECUTE $sql$
+        ALTER TABLE token_tickers SET (
+            timescaledb.compress,
+            timescaledb.compress_segmentby = 'token_symbol, source_code, exchange_id, target_symbol',
+            timescaledb.compress_orderby   = 'ts DESC'
+        )
+    $sql$;
+    BEGIN
+        PERFORM add_compression_policy('token_tickers', INTERVAL '7 days');
+    EXCEPTION WHEN duplicate_object THEN
+        RAISE NOTICE 'compression policy on token_tickers already exists';
+    END;
+    BEGIN
+        PERFORM add_retention_policy('token_tickers', INTERVAL '90 days');
+    EXCEPTION WHEN duplicate_object THEN
+        RAISE NOTICE 'retention policy on token_tickers already exists';
+    END;
+END $$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

Adds **market data** for MVRK: where it trades, at what price, in what
volume - plus pie-chart aggregations for the new Market page. Two new
endpoints, backed by a CoinGecko `/coins/{id}/tickers` collector.

- `GET /v1/tickers/mvrk/latest?in=usd,eur&include_stale=false` - list of
  exchanges with price, 24h volume, 1D change %, exchange logo. Optional
  read-side multi-currency conversion via `?in=` (per ADR-0013).
- `GET /v1/tickers/mvrk/distribution?group_by=exchange|target&in=usd` -
  pie-chart data: share of MVRK volume per exchange OR per quote
  currency.
