### PR TITLE
Per-exchange MVRK market data (tickers + pie distribution)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,32 @@ COINGECKO_RATE_LIMIT_RPS=8
 # RWA_CONCURRENCY=4
 
 # =====================================================================
+# Tickers job (CoinGecko /coins/{id}/tickers — per-exchange market data)
+# Powers /v1/tickers/:token/latest and /v1/tickers/:token/distribution.
+# Disabled by default — flip TICKERS_ENABLED=true after migrations 0012-0014
+# are applied. Single-token in v1 (MVRK); to add more, change the type to
+# []string in config.Tickers and re-introduce a concurrency cap.
+# =====================================================================
+# TICKERS_ENABLED=false
+# TICKERS_TOKEN_SYMBOL=mvrk
+# TICKERS_INTERVAL_SECONDS=300   # 5 min — CoinGecko refreshes tickers slowly
+# TICKERS_HTTP_TIMEOUT=10s
+# TICKERS_INCLUDE_EXCHANGE_LOGO=true   # CG Pro flag; cheap, useful in UI
+
+# In-process snapshot cache TTLs. /distribution costs more to compute
+# (GROUP BY across latest-per-pair) but is called less often, so its TTL
+# is longer at the same hit-ratio.
+# TICKERS_CACHE_LATEST_TTL_SECONDS=30
+# TICKERS_CACHE_DISTRIBUTION_TTL_SECONDS=60
+
+# Server-side stale fence used by /v1/tickers/:token/latest. Rows whose
+# `ts` is older than this are hidden by default; ?include_stale=true opts
+# in. /distribution always excludes stale rows server-side regardless.
+# Tune to ~12 × TICKERS_INTERVAL_SECONDS so a couple of missed ticks
+# don't drop exchanges from the table.
+# SERVER_TICKER_STALE_AFTER=1h
+
+# =====================================================================
 # Equiteez backfill (historical orderbook_order events → rwa_quote_prices, last-only)
 # Disabled by default; opt-in. Same kill-switch story as RWA_ENABLED — both
 # must be true. See docs/adr/0014-rwa-backfill-via-orderbook-order.md.

--- a/grafana/dashboards/mavryk-external-data.json
+++ b/grafana/dashboards/mavryk-external-data.json
@@ -24,7 +24,7 @@
       "gridPos": { "h": 4, "w": 24, "x": 0, "y": 0 },
       "options": {
         "mode": "markdown",
-        "content": "**Mavryk External Data** — observability dashboard.\n\nFour metric families in this board:\n- **HTTP (inbound)** — `http_*` from gin middleware.\n- **Outbound HTTP** — `outbound_http_*` from the resilience stack (CoinGecko + Equiteez). `outbound_http_requests_total{component,outcome}` counts every attempt (incl. retries); subtract `outbound_http_retries_total` to get logical-request RPS.\n- **Background jobs** — `job_*` and `backfill_*` from live, backfill, RWA collectors.\n- **Database pool** — `db_pool_*` sampled every 15s by `metrics.StartDBPoolCollector`.\n\nSet **namespace** to your scrape label (default: `mavryk-external-data`)."
+        "content": "**Mavryk External Data** — observability dashboard.\n\nFive metric families in this board:\n- **HTTP (inbound)** — `http_*` from gin middleware.\n- **Outbound HTTP** — `outbound_http_*` from the resilience stack (CoinGecko + Equiteez). `outbound_http_requests_total{component,outcome}` counts every attempt (incl. retries); subtract `outbound_http_retries_total` to get logical-request RPS.\n- **Background jobs** — `job_*` and `backfill_*` from live, backfill, RWA, tickers collectors.\n- **FX conversions** — `fx_*` from RWA + tickers `?in=` paths.\n- **Tickers** — `tickers_*` for the CoinGecko per-exchange ingestion + per-endpoint cache hit ratios.\n- **Database pool** — `db_pool_*` sampled every 15s by `metrics.StartDBPoolCollector`.\n\nSet **namespace** to your scrape label (default: `mavryk-external-data`)."
       }
     },
 
@@ -227,7 +227,7 @@
         "legendFormat": "{{component}}" }]
     },
 
-    { "type": "row", "id": 20, "title": "Background jobs (live / backfill / RWA)",
+    { "type": "row", "id": 20, "title": "Background jobs (live / backfill / RWA / tickers)",
       "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 52 }, "panels": [] },
 
     {
@@ -337,7 +337,7 @@
         "legendFormat": "wait/s" }]
     },
 
-    { "type": "row", "id": 50, "title": "FX conversions (RWA `?in=`)",
+    { "type": "row", "id": 50, "title": "FX conversions (RWA + tickers `?in=`)",
       "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 99 }, "panels": [] },
 
     {
@@ -384,6 +384,96 @@
       "targets": [{ "refId": "A",
         "expr": "sum by (target) (rate(fx_stale_responses_total{namespace=\"$namespace\"}[$__rate_interval])) / clamp_min(sum by (target) (rate(fx_conversions_total{namespace=\"$namespace\"}[$__rate_interval])), 1e-9)",
         "legendFormat": "{{target}}" }]
+    },
+
+    { "type": "row", "id": 60, "title": "Tickers (CoinGecko per-exchange)", "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 114 }, "panels": [] },
+
+    {
+      "type": "timeseries", "id": 61, "title": "Active (exchange, target) pairs per token",
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 115 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "description": "Distinct (exchange, target_symbol) pairs in the latest CoinGecko tickers tick. Drops between ticks mean exchanges stopped reporting MVRK. Alert on `> 30% drop in 15m`."
+        }
+      },
+      "targets": [{ "refId": "A",
+        "expr": "tickers_active_count{namespace=\"$namespace\"}",
+        "legendFormat": "{{source}}/{{token}}" }]
+    },
+    {
+      "type": "timeseries", "id": 62, "title": "Distinct exchanges per token",
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 115 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "description": "Distinct exchanges reporting the token in the latest tick. Coarser than `tickers_active_count` — fires when an exchange disappears entirely (vs. dropping one of multiple pairs)."
+        }
+      },
+      "targets": [{ "refId": "A",
+        "expr": "tickers_exchanges_count{namespace=\"$namespace\"}",
+        "legendFormat": "{{source}}/{{token}}" }]
+    },
+    {
+      "type": "timeseries", "id": 63, "title": "Tickers job tick p95 (job=tickers)",
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 122 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "description": "p95 wall-time of one CoinGecko tickers job tick. Default cadence is 5m; ticks taking > 30s suggest CG /tickers is slow or returning a large payload (lots of exchanges)."
+        }
+      },
+      "targets": [{ "refId": "A",
+        "expr": "histogram_quantile(0.95, sum by (entity, le) (rate(job_tick_duration_seconds_bucket{namespace=\"$namespace\", job=\"tickers\"}[$__rate_interval])))",
+        "legendFormat": "{{entity}}" }]
+    },
+    {
+      "type": "timeseries", "id": 64, "title": "Tickers job errors by reason (rate)",
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 122 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "description": "Tickers job errors per second by reason. `fetch` = CoinGecko request failed (rate-limit / 5xx / network). `save` = DB write failed (FK / connection)."
+        }
+      },
+      "targets": [{ "refId": "A",
+        "expr": "sum by (reason) (rate(job_errors_total{namespace=\"$namespace\", job=\"tickers\"}[$__rate_interval]))",
+        "legendFormat": "{{reason}}" }]
+    },
+    {
+      "type": "timeseries", "id": 65, "title": "Tickers cache hit ratio (latest + distribution)",
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 129 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "description": "Share of /v1/tickers requests served from the in-process cache. Default TTLs: latest=30s, distribution=60s. Healthy under regular polling is `> 0.5`; drops below mean clients are out-pacing the cache (or each request carries a unique `?in=` cardinality)."
+        }
+      },
+      "targets": [{ "refId": "A",
+        "expr": "sum by (endpoint) (rate(tickers_cache_requests_total{namespace=\"$namespace\", result=\"hit\"}[$__rate_interval])) / clamp_min(sum by (endpoint) (rate(tickers_cache_requests_total{namespace=\"$namespace\"}[$__rate_interval])), 1e-9)",
+        "legendFormat": "{{endpoint}}" }]
+    },
+    {
+      "type": "timeseries", "id": 66, "title": "Tickers HTTP p95 by endpoint",
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 129 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "description": "p95 inbound latency for /v1/tickers/* endpoints. Cache hits should be sub-1ms; spikes mean cache miss → SQL roundtrip (DISTINCT ON + LATERAL for /latest, GROUP BY for /distribution)."
+        }
+      },
+      "targets": [{ "refId": "A",
+        "expr": "histogram_quantile(0.95, sum by (path, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", path=~\"/v1/tickers/.*\"}[$__rate_interval])))",
+        "legendFormat": "{{path}}" }]
     }
   ],
   "preload": false,
@@ -411,6 +501,6 @@
   "timezone": "browser",
   "title": "Mavryk External Data (Quotes)",
   "uid": "mavryk-external-data-quotes",
-  "version": 4,
+  "version": 5,
   "weekStart": ""
 }

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -44,6 +44,7 @@ func overrideWithEnv(config *Config) error {
 		{"SERVER_WRITE_TIMEOUT", &config.Server.WriteTimeout},
 		{"SERVER_READ_HEADER_TIMEOUT", &config.Server.ReadHeaderTimeout},
 		{"SERVER_IDLE_TIMEOUT", &config.Server.IdleTimeout},
+		{"SERVER_TICKER_STALE_AFTER", &config.Server.TickerStaleAfter},
 	} {
 		if v := os.Getenv(e.env); v != "" {
 			d, err := time.ParseDuration(v)
@@ -289,6 +290,47 @@ func overrideWithEnv(config *Config) error {
 			return fmt.Errorf("RWA_CONCURRENCY: invalid int %q: %w", v, err)
 		}
 		config.RWA.Concurrency = val
+	}
+
+	if v := os.Getenv("TICKERS_ENABLED"); v != "" {
+		val, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("TICKERS_ENABLED: invalid bool %q: %w", v, err)
+		}
+		config.Tickers.Enabled = val
+	}
+	if v := os.Getenv("TICKERS_TOKEN_SYMBOL"); v != "" {
+		config.Tickers.TokenSymbol = v
+	}
+	if v := os.Getenv("TICKERS_INCLUDE_EXCHANGE_LOGO"); v != "" {
+		val, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("TICKERS_INCLUDE_EXCHANGE_LOGO: invalid bool %q: %w", v, err)
+		}
+		config.Tickers.IncludeExchangeLogo = val
+	}
+	for _, e := range []struct {
+		env string
+		dst *int
+	}{
+		{"TICKERS_INTERVAL_SECONDS", &config.Tickers.IntervalSeconds},
+		{"TICKERS_CACHE_LATEST_TTL_SECONDS", &config.Tickers.Cache.LatestTTLSeconds},
+		{"TICKERS_CACHE_DISTRIBUTION_TTL_SECONDS", &config.Tickers.Cache.DistributionTTLSeconds},
+	} {
+		if v := os.Getenv(e.env); v != "" {
+			val, err := strconv.Atoi(v)
+			if err != nil {
+				return fmt.Errorf("%s: invalid int %q: %w", e.env, v, err)
+			}
+			*e.dst = val
+		}
+	}
+	if v := os.Getenv("TICKERS_HTTP_TIMEOUT"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("TICKERS_HTTP_TIMEOUT: invalid duration %q: %w", v, err)
+		}
+		config.Tickers.HTTPTimeout = DurationYAML(d)
 	}
 
 	if v := os.Getenv("AUTH_ENABLED"); v != "" {

--- a/internal/core/application/tickers/cache.go
+++ b/internal/core/application/tickers/cache.go
@@ -7,6 +7,7 @@ import (
 
 	"quotes/internal/core/application/cache"
 	"quotes/internal/core/domain/tickers"
+	"quotes/internal/metrics"
 )
 
 // CachedRepository wraps a Repository with per-endpoint TTL caches.
@@ -75,9 +76,17 @@ func (c *CachedRepository) LatestSnapshot(ctx context.Context, q LatestQuery) (t
 		return c.inner.LatestSnapshot(ctx, q)
 	}
 	key := latestKey(q)
-	return c.latest.GetOrLoad(ctx, key, func(ctx context.Context) (tickers.Snapshot, error) {
-		return c.inner.LatestSnapshot(ctx, q)
-	})
+	if v, ok := c.latest.Lookup(key); ok {
+		metrics.TickersCacheRequestsTotal.WithLabelValues("latest", "hit").Inc()
+		return v, nil
+	}
+	metrics.TickersCacheRequestsTotal.WithLabelValues("latest", "miss").Inc()
+	v, err := c.inner.LatestSnapshot(ctx, q)
+	if err != nil {
+		return tickers.Snapshot{}, err
+	}
+	c.latest.Store(key, v)
+	return v, nil
 }
 
 func (c *CachedRepository) VolumeDistribution(ctx context.Context, q DistributionQuery) (tickers.Distribution, error) {
@@ -85,9 +94,17 @@ func (c *CachedRepository) VolumeDistribution(ctx context.Context, q Distributio
 		return c.inner.VolumeDistribution(ctx, q)
 	}
 	key := distributionKey(q)
-	return c.distribution.GetOrLoad(ctx, key, func(ctx context.Context) (tickers.Distribution, error) {
-		return c.inner.VolumeDistribution(ctx, q)
-	})
+	if v, ok := c.distribution.Lookup(key); ok {
+		metrics.TickersCacheRequestsTotal.WithLabelValues("distribution", "hit").Inc()
+		return v, nil
+	}
+	metrics.TickersCacheRequestsTotal.WithLabelValues("distribution", "miss").Inc()
+	v, err := c.inner.VolumeDistribution(ctx, q)
+	if err != nil {
+		return tickers.Distribution{}, err
+	}
+	c.distribution.Store(key, v)
+	return v, nil
 }
 
 func latestKey(q LatestQuery) string {

--- a/internal/core/infrastructure/jobs/coingecko_tickers.go
+++ b/internal/core/infrastructure/jobs/coingecko_tickers.go
@@ -138,6 +138,16 @@ func (j *CoinGeckoTickersJob) collectOnce(ctx context.Context, token prices.Toke
 	metrics.JobRowsAffectedTotal.
 		WithLabelValues("tickers", string(j.source), string(token)).
 		Add(float64(n))
+	// Snapshot gauges — distinct (exchange, target) and distinct exchanges
+	// observed in THIS tick. Set unconditionally on a successful save so the
+	// gauge reflects the freshest reality, even when n==0 (mapper found rows
+	// but the DB had them all already → ON CONFLICT DO NOTHING).
+	metrics.TickersActiveCount.
+		WithLabelValues(string(j.source), string(token)).
+		Set(float64(len(rows)))
+	metrics.TickersExchangesCount.
+		WithLabelValues(string(j.source), string(token)).
+		Set(float64(len(exchanges)))
 	logger.Info().
 		Int("exchanges", len(exchanges)).
 		Int("rows", len(rows)).

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -266,6 +266,45 @@ var (
 		},
 		[]string{"kind", "code"},
 	)
+
+	// TickersActiveCount — gauge of distinct (exchange, target_symbol) pairs
+	// observed in the latest CoinGecko tickers tick, per token. Set after each
+	// successful job tick. A drop from 50 → 30 between ticks means CoinGecko
+	// stopped reporting ~20 pairs (exchange delisted, market paused) — alert
+	// when this gauge falls more than ~30% in 15min.
+	TickersActiveCount = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "tickers_active_count",
+			Help: "Distinct (exchange, target_symbol) pairs in the last CoinGecko tickers tick, per token.",
+		},
+		[]string{"source", "token"},
+	)
+
+	// TickersExchangesCount — gauge of distinct exchanges observed in the
+	// latest tick, per token. Useful as a coarser signal than
+	// TickersActiveCount (catches "Binance delisted MVRK" even if Binance
+	// previously had only one pair).
+	TickersExchangesCount = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "tickers_exchanges_count",
+			Help: "Distinct exchanges reporting the token in the last CoinGecko tickers tick.",
+		},
+		[]string{"source", "token"},
+	)
+
+	// TickersCacheRequestsTotal — counter of cache outcomes for the in-process
+	// snapshot caches that back /v1/tickers/:token/latest and /distribution.
+	// endpoint ∈ {latest, distribution}; result ∈ {hit, miss}.
+	// hit_ratio = sum(hit) / (sum(hit) + sum(miss)) per endpoint — alert when
+	// hit_ratio drops below ~0.5 (cache too small / TTL too short / poll rate
+	// pathological).
+	TickersCacheRequestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tickers_cache_requests_total",
+			Help: "Outcome of tickers in-process cache lookups, per endpoint.",
+		},
+		[]string{"endpoint", "result"},
+	)
 )
 
 // StatusClass returns 2xx, 4xx, or 5xx for HTTPResponsesTotal labelling.


### PR DESCRIPTION
Adds **market data** for MVRK — where it trades, at what price, in what
volume. Two new endpoints + a CoinGecko `/coins/{id}/tickers` collector.
