### PR TITLE
Add ath + priceOneYearAgo to RWA /latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ run:
 	@echo "Running application..."
 	go run cmd/quotes/main.go
 
+# Mint an RS256 Bearer JWT for the RWA routes, signed with secret.key.
+# Override fields via flags, e.g. `make jwt JWT_ARGS="--ttl 24h"`.
+jwt:
+	@go run cmd/jwtgen/main.go $(JWT_ARGS)
+
 test:
 	@echo "Running tests..."
 	go test -race -timeout 5m -cover ./...

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,6 @@ run:
 	@echo "Running application..."
 	go run cmd/quotes/main.go
 
-# Mint an RS256 Bearer JWT for the RWA routes, signed with secret.key.
-# Override fields via flags, e.g. `make jwt JWT_ARGS="--ttl 24h"`.
 jwt:
 	@go run cmd/jwtgen/main.go $(JWT_ARGS)
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -35,8 +35,7 @@ tags:
     description: RWA orderbook prices (Equiteez)
   - name: charts-ft
     description: |
-      Time-series charts (line, OHLC, OHLCV) over `token_prices`. See
-      [ADR-0015](https://github.com/0xVoronov/mavryk-external-data/blob/main/docs/adr/0015-charts-line-ohlc-ohlcv.md).
+      Time-series charts (line, OHLC, OHLCV) over `token_prices`.
       Ships `/series` and `/ohlc` for `1m / 5m / 15m / 1h / 4h / 1d`;
       `/ohlcv` returns 501 until volume ingestion lands.
   - name: charts-rwa
@@ -44,7 +43,7 @@ tags:
       Time-series charts (line, OHLC, OHLCV) over `rwa_quote_prices`. Same
       DTO shape as `charts-ft`; uses the `last` orderbook side for every
       bucket. Pre-deploy history depends on `equiteez_backfill.go` having
-      been enabled (see [ADR-0014](https://github.com/0xVoronov/mavryk-external-data/blob/main/docs/adr/0014-rwa-backfill-via-orderbook-order.md)).
+      been enabled.
       `/ohlcv` shares the same 501 stub as `charts-ft` until volume
       ingestion lands.
   - name: prices-tickers
@@ -54,7 +53,7 @@ tags:
       change %, plus a pie-chart `/distribution` endpoint that aggregates
       volume by exchange or quote currency. Conversion to any supported
       `?in=usd,eur,...` happens read-side via the same FX rates used by
-      `prices-rwa` (ADR-0013).
+      `prices-rwa`.
   - name: discovery
     description: |
       Catalog endpoints for clients that need to know which entities are
@@ -258,7 +257,7 @@ paths:
         of `_1m` and `_1h` at query time.
 
         Either `from`+`to` define a window or both are absent for
-        latest mode. Range caps per interval (see ADR-0015):
+        latest mode. Range caps per interval:
         `1m` ≤ 7 days, `1h` ≤ 1 year, `1d` unlimited.
 
         `currency` is required (one value, no comma-list).
@@ -333,7 +332,7 @@ paths:
       summary: OHLCV candles (Stage 4 — TODO)
       description: |
         Reserved URL. Returns **501** with code `OHLCV_NOT_IMPLEMENTED`
-        until volume ingestion ships (see ADR-0015). `token_prices`
+        until volume ingestion ships. `token_prices`
         does not yet store volume; CoinGecko `/simple/price` doesn't
         return it. Frontend can build against this URL safely — the
         DTO shape is fixed (see `OHLCVResponse`).
@@ -398,11 +397,11 @@ paths:
         and `_1h` at query time.
 
         History before service deploy depends on `equiteez_backfill.go`
-        having been enabled (see ADR-0014).
+        having been enabled.
 
         Optional `?in=<currency>` adds a flat top-level numeric key per
         point with the close price converted at the close-of-bucket FX
-        rate (see ADR-0015). Cap = 1 — multiple comma-separated values
+        rate. Cap = 1 — multiple comma-separated values
         return 400.
       operationId: rwaSeries
       parameters:
@@ -445,8 +444,8 @@ paths:
         Same `interval` / range cap semantics as `/series`.
 
         Optional `?in=<currency>` adds a nested object per candle with
-        converted `o/h/l/c` plus `rate` and `rate_ts` (close-of-bucket FX;
-        see ADR-0015). One rate per candle keeps the converted candle
+        converted `o/h/l/c` plus `rate` and `rate_ts` (close-of-bucket FX).
+        One rate per candle keeps the converted candle
         valid (`l ≤ o,c ≤ h`).
       operationId: rwaOHLC
       parameters:
@@ -494,8 +493,8 @@ paths:
       summary: OHLCV candles for an RWA pair (Stage 4 — TODO)
       description: |
         Reserved URL. Returns **501** with code `OHLCV_NOT_IMPLEMENTED`
-        until traded-volume from the `orderbook_order` event log lands
-        (see ADR-0015). The existing `rwa_quote_prices.size` column is
+        until traded-volume from the `orderbook_order` event log lands.
+        The existing `rwa_quote_prices.size` column is
         a top-of-book snapshot, not traded volume — using it would
         mislead the frontend. DTO shape is fixed (`OHLCVResponse`) so
         the frontend can build against this URL today.
@@ -561,7 +560,7 @@ paths:
           top-level numeric keys, same convention as
           `/v1/rwa/{symbol}/latest?in=`. The conversion uses the
           at-or-before FX rate matching the `now` timestamp — historical
-          accuracy is preserved (see ADR-0013 addendum / `fix_todo.md`).
+          accuracy is preserved.
         - Period anchors come from raw `rwa_quote_prices` via PK index
           seek, same data source as `now` for symmetry.
       operationId: rwaChange
@@ -609,7 +608,7 @@ paths:
         Optional `?in=usd,eur,...` adds a nested `in.<target>` block per
         row carrying the converted `price`, `volume_24h`, and FX
         metadata. Conversion uses the FT-side `token_prices` series as
-        the FX source (ADR-0013). Per-target failures populate
+        the FX source. Per-target failures populate
         `in.<target>.fx.error`; numeric fields are omitted but the parent
         response stays 200.
       operationId: latestTickers
@@ -864,7 +863,7 @@ components:
       description: |
         Bucket size for the chart. `raw` is reserved for tick-level series
         (rejected for `/ohlc` and `/ohlcv`, and not yet supported for FA
-        charts). Per-interval window caps are documented in ADR-0015.
+        charts). Per-interval window caps apply (see the range parameters).
       schema:
         type: string
         enum: [raw, 1m, 5m, 15m, 1h, 4h, 1d]
@@ -887,7 +886,7 @@ components:
       in: query
       required: false
       description: |
-        Single target currency for close-of-bucket FX conversion (see ADR-0015).
+        Single target currency for close-of-bucket FX conversion.
         Each chart endpoint caps `?in=` to one value — comma-separated lists
         return 400. Used by RWA charts to convert from the pair's native
         quote (e.g. `usdt`) to a registered currency (`usd`, `eur`, …).
@@ -941,7 +940,7 @@ components:
     RangeNotSatisfiable:
       description: |
         The requested `from..to` window exceeds the per-interval cap
-        (`code: RANGE_NOT_SATISFIABLE`; see ADR-0015). Distinct from
+        (`code: RANGE_NOT_SATISFIABLE`). Distinct from
         `400 INVALID_ARGUMENT` so clients can render a "narrow your range"
         UX without parsing the message. Caps: `1m` ≤ 7d, `5m` ≤ 30d,
         `15m` ≤ 90d, `1h` ≤ 1y, `4h` ≤ 4y; `1d` is unlimited.
@@ -1142,7 +1141,7 @@ components:
       description: |
         One candle without volume. When `?in=<currency>` is supplied the
         converted o/h/l/c plus `rate`/`rate_ts` appear as a nested object
-        keyed by the target currency (see ADR-0015).
+        keyed by the target currency.
       required: [t, o, h, l, c, n]
       properties:
         t: { type: string, format: date-time, description: Bucket start time (RFC3339 UTC). }

--- a/internal/core/api/http/app.go
+++ b/internal/core/api/http/app.go
@@ -232,6 +232,8 @@ func buildRouterDeps(deps AppDeps, cfg *config.Config, gate *handlers.ReadinessG
 		MaxLimit:        cfg.Server.MaxQueryLimit,
 		DefaultLimit:    100,
 		MaxInCurrencies: cfg.Server.MaxInCurrencies,
+		// ath + price-one-year-ago for /latest; same concrete repo as charts.
+		Stats: deps.RWAPriceRepo,
 	}
 	// RWA chart service runs over RWAPriceRepository. Converter enables
 	// `?in=<currency>` close-of-bucket FX (see ADR-0015 / ADR-0013); when

--- a/internal/core/api/http/app.go
+++ b/internal/core/api/http/app.go
@@ -97,10 +97,11 @@ func NewApp(deps AppDeps) (*App, error) {
 	publicEngine := buildPublicEngine(cfg, appLogger)
 	publicDeps := routerDepsBase
 	publicDeps.RWAAuth = rwaAuth
-	// Docs (Swagger UI + openapi.yaml) get mounted on the internal listener
-	// when one exists; here on the public engine only as a fallback for
-	// single-port local-dev runs.
-	publicDeps.MountDocs = strings.TrimSpace(cfg.Server.InternalPort) == ""
+	// Docs (Swagger UI + openapi.yaml) are mounted on the public engine in every
+	// mode. Access to /docs and /openapi.yaml is gated at the infrastructure
+	// layer (reverse proxy / network policy), not in the app — so we expose them
+	// unconditionally here and let the edge decide who reaches them.
+	publicDeps.MountDocs = true
 	SetupRoutes(publicEngine, publicDeps)
 
 	publicServer := &http.Server{

--- a/internal/core/api/http/handlers/rwa_prices.go
+++ b/internal/core/api/http/handlers/rwa_prices.go
@@ -34,6 +34,15 @@ type PairLookup interface {
 	LookupRWAPairBySymbol(ctx context.Context, base, quote string) (prices.RWAPair, error)
 }
 
+// RWAStatsReader supplies the derived per-pair stats that enrich the /latest
+// snapshot: the all-time-high (price + date) and the price one year ago. Both
+// are read on the `last` side. Optional on RWAPriceDeps — when the reader is
+// nil, /latest simply omits the `ath` / `price_one_year_ago` blocks.
+type RWAStatsReader interface {
+	AllTimeHighLast(ctx context.Context, pairID int64, side string) (decimal.Decimal, time.Time, bool, error)
+	PriceAtOrBefore(ctx context.Context, pairID int64, side string, ts time.Time) (decimal.Decimal, time.Time, bool, error)
+}
+
 // RWAPriceDeps wires the RWA-side dependencies.
 type RWAPriceDeps struct {
 	Service       apiprices.QueryService
@@ -45,6 +54,10 @@ type RWAPriceDeps struct {
 	// MaxInCurrencies caps the number of comma-separated currencies in `?in=`.
 	// 0 means unlimited (not recommended); production should pin to e.g. 10.
 	MaxInCurrencies int
+	// Stats is optional; supplies ath + price-one-year-ago for /latest. When
+	// nil those blocks are omitted (keeps the endpoint back-compatible and lets
+	// unit tests that don't exercise them stay minimal).
+	Stats RWAStatsReader
 }
 
 // ListBySymbol — GET /v1/rwa/:symbol
@@ -162,9 +175,45 @@ func (d RWAPriceDeps) LatestBySymbol() gin.HandlerFunc {
 		if len(req.InTargets) > 0 {
 			dto.Converted = d.convertFlat(ctx, quoteToken, quoteResolved, req.InTargets, picked.Price, picked.Timestamp)
 		}
+		d.enrichLatest(ctx, &dto, req.Pair, quoteToken, quoteResolved, req.InTargets)
 		return dto, nil
 	}
 	return common.Wrap(bind, action)
+}
+
+// enrichLatest adds the `ath` and `price_one_year_ago` blocks to a /latest DTO
+// when a Stats reader is configured. Each block carries the native-quote value
+// plus — when `?in=` targets are present — the same flat per-currency
+// conversions as the top-level price, converted at the block's own timestamp
+// (ATH at the ATH date; the year-ago price at its observation time). A nil
+// reader, missing data, or a repo error simply omits the block: the core price
+// snapshot still returns 200.
+func (d RWAPriceDeps) enrichLatest(
+	ctx context.Context,
+	dto *rwaPriceDTO,
+	pair prices.RWAPair,
+	quoteToken prices.Token,
+	quoteResolved bool,
+	targets []prices.Currency,
+) {
+	if d.Stats == nil {
+		return
+	}
+	if price, ts, found, err := d.Stats.AllTimeHighLast(ctx, pair.ID, lastSide); err == nil && found {
+		ath := &athDTO{Price: newNum6(price), Date: ts.Format("2006-01-02")}
+		if len(targets) > 0 {
+			ath.Converted = d.convertFlat(ctx, quoteToken, quoteResolved, targets, price, ts)
+		}
+		dto.ATH = ath
+	}
+	yearAgo := time.Now().UTC().AddDate(-1, 0, 0)
+	if price, ts, found, err := d.Stats.PriceAtOrBefore(ctx, pair.ID, lastSide, yearAgo); err == nil && found {
+		p1y := &priceAtDTO{Price: newNum6(price)}
+		if len(targets) > 0 {
+			p1y.Converted = d.convertFlat(ctx, quoteToken, quoteResolved, targets, price, ts)
+		}
+		dto.PriceOneYearAgo = p1y
+	}
 }
 
 // --- DTO ---
@@ -182,6 +231,11 @@ type rwaPriceDTO struct {
 	NativeQuote string
 	Price       num6
 	Converted   map[string]num6 // optional; one key per `?in=` target that succeeded
+	// Optional enrichment (only on /latest, only when a Stats reader is wired).
+	// `ath` / `price_one_year_ago` are nested objects (not flat currency keys)
+	// so they don't collide with the top-level converted-price currency keys.
+	ATH             *athDTO
+	PriceOneYearAgo *priceAtDTO
 }
 
 func (d rwaPriceDTO) MarshalJSON() ([]byte, error) {
@@ -190,6 +244,49 @@ func (d rwaPriceDTO) MarshalJSON() ([]byte, error) {
 	out["native_quote"] = d.NativeQuote
 	out["price"] = d.Price
 	for cur, v := range d.Converted {
+		out[cur] = v
+	}
+	if d.ATH != nil {
+		out["ath"] = d.ATH
+	}
+	if d.PriceOneYearAgo != nil {
+		out["price_one_year_ago"] = d.PriceOneYearAgo
+	}
+	return json.Marshal(out)
+}
+
+// athDTO is the all-time-high block on /latest: native-quote `price`, the
+// `date` (YYYY-MM-DD) it occurred, plus one numeric key per `?in=` currency
+// (converted at the ATH date). Same flat-currency-inline convention as
+// rwaPriceDTO, scoped inside the `ath` object.
+type athDTO struct {
+	Price     num6
+	Date      string
+	Converted map[string]num6
+}
+
+func (a athDTO) MarshalJSON() ([]byte, error) {
+	out := make(map[string]any, 2+len(a.Converted))
+	out["price"] = a.Price
+	out["date"] = a.Date
+	for cur, v := range a.Converted {
+		out[cur] = v
+	}
+	return json.Marshal(out)
+}
+
+// priceAtDTO is a bare price block (price-one-year-ago): native-quote `price`
+// plus one numeric key per `?in=` currency, converted at the observation
+// timestamp of that historical point.
+type priceAtDTO struct {
+	Price     num6
+	Converted map[string]num6
+}
+
+func (p priceAtDTO) MarshalJSON() ([]byte, error) {
+	out := make(map[string]any, 1+len(p.Converted))
+	out["price"] = p.Price
+	for cur, v := range p.Converted {
 		out[cur] = v
 	}
 	return json.Marshal(out)

--- a/internal/core/api/http/handlers/rwa_prices_test.go
+++ b/internal/core/api/http/handlers/rwa_prices_test.go
@@ -653,3 +653,168 @@ func (s *stubFnConverter) Convert(
 ) (apiprices.ConversionResult, error) {
 	return s.fn(ctx, src, target, amt, ts)
 }
+
+// stubStats satisfies RWAStatsReader. Returns the configured ath / price-at
+// values and records call counts so tests can assert the reader is consulted.
+type stubStats struct {
+	athPrice decimal.Decimal
+	athTS    time.Time
+	athFound bool
+	athErr   error
+	p1yPrice decimal.Decimal
+	p1yTS    time.Time
+	p1yFound bool
+	p1yErr   error
+	athCalls int
+	p1yCalls int
+}
+
+func (s *stubStats) AllTimeHighLast(_ context.Context, _ int64, _ string) (decimal.Decimal, time.Time, bool, error) {
+	s.athCalls++
+	return s.athPrice, s.athTS, s.athFound, s.athErr
+}
+
+func (s *stubStats) PriceAtOrBefore(_ context.Context, _ int64, _ string, _ time.Time) (decimal.Decimal, time.Time, bool, error) {
+	s.p1yCalls++
+	return s.p1yPrice, s.p1yTS, s.p1yFound, s.p1yErr
+}
+
+// TestRWA_Latest_StatsEnriched — with a Stats reader, /latest carries the
+// `ath {price,date}` and `price_one_year_ago {price}` blocks (native quote, no `?in=`).
+func TestRWA_Latest_StatsEnriched(t *testing.T) {
+	svc, lookup := rwaLastPointForTests(t)
+	stats := &stubStats{
+		athPrice: decimal.NewFromFloat(161.0),
+		athTS:    time.Date(2025, 10, 6, 0, 0, 0, 0, time.UTC),
+		athFound: true,
+		p1yPrice: decimal.NewFromFloat(84.0),
+		p1yTS:    time.Date(2025, 4, 28, 12, 0, 0, 0, time.UTC),
+		p1yFound: true,
+	}
+	deps := RWAPriceDeps{Service: svc, Lookup: lookup, DefaultSource: prices.SourceEquiteez, Stats: stats}
+	r := newRWAEngine(t, deps)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/rwa/tst-usdt/latest", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v\n%s", err, w.Body.String())
+	}
+
+	ath, ok := got["ath"].(map[string]any)
+	if !ok {
+		t.Fatalf("ath missing or not an object: %v; body=%s", got["ath"], w.Body.String())
+	}
+	if p, ok := ath["price"].(float64); !ok || p != 161.0 {
+		t.Errorf("ath.price = %v, want 161.0", ath["price"])
+	}
+	if ath["date"] != "2025-10-06" {
+		t.Errorf("ath.date = %v, want 2025-10-06", ath["date"])
+	}
+
+	p1y, ok := got["price_one_year_ago"].(map[string]any)
+	if !ok {
+		t.Fatalf("price_one_year_ago missing or not an object: %v", got["price_one_year_ago"])
+	}
+	if p, ok := p1y["price"].(float64); !ok || p != 84.0 {
+		t.Errorf("price_one_year_ago.price = %v, want 84.0", p1y["price"])
+	}
+}
+
+// TestRWA_Latest_StatsConverted — `?in=usd` converts the ath and year-ago
+// blocks at their own timestamps, inlined as flat currency keys inside each.
+func TestRWA_Latest_StatsConverted(t *testing.T) {
+	svc, lookup := rwaLastPointForTests(t)
+	conv := &stubConverter{result: apiprices.ConversionResult{
+		Rate:   decimal.NewFromInt(2),
+		Source: prices.SourceCoinGecko,
+		RateTS: time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC),
+	}}
+	stats := &stubStats{
+		athPrice: decimal.NewFromFloat(161.0),
+		athTS:    time.Date(2025, 10, 6, 0, 0, 0, 0, time.UTC),
+		athFound: true,
+		p1yPrice: decimal.NewFromFloat(84.0),
+		p1yTS:    time.Date(2025, 4, 28, 12, 0, 0, 0, time.UTC),
+		p1yFound: true,
+	}
+	deps := RWAPriceDeps{
+		Service: svc, Converter: conv, Lookup: lookup,
+		DefaultSource: prices.SourceEquiteez, MaxInCurrencies: 10, Stats: stats,
+	}
+	r := newRWAEngine(t, deps)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/rwa/tst-usdt/latest?in=usd", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v\n%s", err, w.Body.String())
+	}
+
+	ath := got["ath"].(map[string]any)
+	if usd, ok := ath["usd"].(float64); !ok || usd != 322.0 { // 161 * 2
+		t.Errorf("ath.usd = %v, want 322.0", ath["usd"])
+	}
+	p1y := got["price_one_year_ago"].(map[string]any)
+	if usd, ok := p1y["usd"].(float64); !ok || usd != 168.0 { // 84 * 2
+		t.Errorf("price_one_year_ago.usd = %v, want 168.0", p1y["usd"])
+	}
+}
+
+// TestRWA_Latest_NoStats_OmitsBlocks — with no Stats reader wired, the ath /
+// price_one_year_ago keys are absent (back-compat with existing consumers).
+func TestRWA_Latest_NoStats_OmitsBlocks(t *testing.T) {
+	svc, lookup := rwaLastPointForTests(t)
+	deps := RWAPriceDeps{Service: svc, Lookup: lookup, DefaultSource: prices.SourceEquiteez}
+	r := newRWAEngine(t, deps)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/rwa/tst-usdt/latest", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := got["ath"]; ok {
+		t.Errorf("ath present without a Stats reader")
+	}
+	if _, ok := got["price_one_year_ago"]; ok {
+		t.Errorf("price_one_year_ago present without a Stats reader")
+	}
+}
+
+// TestRWA_Latest_StatsNotFound_OmitsBlocks — the reader is consulted but has no
+// data (found=false); the blocks are omitted and the core price still returns 200.
+func TestRWA_Latest_StatsNotFound_OmitsBlocks(t *testing.T) {
+	svc, lookup := rwaLastPointForTests(t)
+	stats := &stubStats{athFound: false, p1yFound: false}
+	deps := RWAPriceDeps{Service: svc, Lookup: lookup, DefaultSource: prices.SourceEquiteez, Stats: stats}
+	r := newRWAEngine(t, deps)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/rwa/tst-usdt/latest", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := got["ath"]; ok {
+		t.Errorf("ath present when reader returned found=false")
+	}
+	if _, ok := got["price_one_year_ago"]; ok {
+		t.Errorf("price_one_year_ago present when reader returned found=false")
+	}
+	if stats.athCalls != 1 || stats.p1yCalls != 1 {
+		t.Errorf("reader calls = (ath %d, p1y %d), want (1,1)", stats.athCalls, stats.p1yCalls)
+	}
+}

--- a/internal/core/api/http/router.go
+++ b/internal/core/api/http/router.go
@@ -13,11 +13,10 @@ import (
 // middleware. It is non-nil on the public listener and nil on the internal
 // listener — same handler graph, same code path, different exposure surface.
 //
-// MountDocs, when true, registers /openapi.yaml and /docs (Swagger UI). When
-// the two-listener layout is active these are mounted on the internal engine
-// only — the API spec is operator documentation, not customer-facing. In
-// single-port mode (no internal listener) docs go on the public engine so
-// local-dev `curl /docs` still works.
+// MountDocs, when true, registers /openapi.yaml and /docs (Swagger UI). It is
+// true on both listeners: the spec and Swagger UI are exposed on the public
+// engine and access is gated at the infrastructure layer (reverse proxy /
+// network policy), not in the app.
 //
 // See app.go for the wiring.
 type RouterDeps struct {
@@ -42,8 +41,8 @@ type RouterDeps struct {
 //	/healthz                 — liveness
 //	/readyz                  — readiness (db ping + drain gate)
 //	/metrics                 — Prometheus (internal listener only)
-//	/openapi.yaml            — embedded OpenAPI 3.0 spec (internal only when two-port)
-//	/docs                    — Swagger UI (internal only when two-port)
+//	/openapi.yaml            — embedded OpenAPI 3.0 spec (public; gated at the edge)
+//	/docs                    — Swagger UI (public; gated at the edge)
 //	/quotes                  — legacy v0.1.0 wide-format MVRK quotes
 //	/v1/prices/:token         — list (range or latest)
 //	/v1/prices/:token/latest  — transposed snapshot
@@ -68,9 +67,9 @@ func SetupRoutes(engine *gin.Engine, deps RouterDeps) {
 	engine.GET("/quotes", deps.LegacyQuotes.LegacyQuotes())
 
 	// Static OpenAPI 3.0 spec + Swagger UI shell. Both bytes are embedded at
-	// compile time via docs.OpenAPIYAML / docs.SwaggerUIHTML. In two-listener
-	// mode these live on the internal engine only — the public listener does
-	// not expose the API spec.
+	// compile time via docs.OpenAPIYAML / docs.SwaggerUIHTML. Mounted on the
+	// public listener; access is restricted at the infrastructure layer rather
+	// than in the app.
 	if deps.MountDocs {
 		engine.GET("/openapi.yaml", handlers.OpenAPISpec())
 		engine.GET("/docs", handlers.SwaggerUI())

--- a/internal/core/infrastructure/storage/repositories/rwa_price_repository.go
+++ b/internal/core/infrastructure/storage/repositories/rwa_price_repository.go
@@ -277,11 +277,14 @@ func (r *RWAPriceRepository) AllTimeHighLast(
 		HighPrice decimal.Decimal `gorm:"column:high_price"`
 		Bucket    time.Time       `gorm:"column:bucket"`
 	}
+	// The 1d CAGG stores the daily high as `max_price` (see migration 0010);
+	// alias it to high_price so the scan struct binds. Mirrors the
+	// max_price→high_price alias the chart SQL already uses (candle_sql.go).
 	err := r.db.WithContext(ctx).Raw(
-		`SELECT high_price, bucket
+		`SELECT max_price AS high_price, bucket
 		   FROM rwa_quote_prices_1d
 		  WHERE pair_id = ? AND side = ?
-		  ORDER BY high_price DESC
+		  ORDER BY max_price DESC
 		  LIMIT 1`,
 		pairID, side).Scan(&rows).Error
 	if err != nil {

--- a/internal/core/infrastructure/storage/repositories/rwa_price_repository.go
+++ b/internal/core/infrastructure/storage/repositories/rwa_price_repository.go
@@ -264,3 +264,58 @@ func rwaEntitiesToPoints(rows []entities.RWAQuotePriceEntity, source prices.Sour
 	}
 	return out
 }
+
+// AllTimeHighLast returns the highest price ever recorded for a pair on the
+// given side, plus the day it occurred. It reads the 1d continuous aggregate
+// (rwa_quote_prices_1d.high_price): the max daily high across all buckets is
+// the all-time high, and that bucket is the ATH date. The read contract passes
+// side="last". found=false when the pair has no aggregated rows yet.
+func (r *RWAPriceRepository) AllTimeHighLast(
+	ctx context.Context, pairID int64, side string,
+) (decimal.Decimal, time.Time, bool, error) {
+	var rows []struct {
+		HighPrice decimal.Decimal `gorm:"column:high_price"`
+		Bucket    time.Time       `gorm:"column:bucket"`
+	}
+	err := r.db.WithContext(ctx).Raw(
+		`SELECT high_price, bucket
+		   FROM rwa_quote_prices_1d
+		  WHERE pair_id = ? AND side = ?
+		  ORDER BY high_price DESC
+		  LIMIT 1`,
+		pairID, side).Scan(&rows).Error
+	if err != nil {
+		return decimal.Decimal{}, time.Time{}, false, fmt.Errorf("query rwa all-time high: %w", err)
+	}
+	if len(rows) == 0 {
+		return decimal.Decimal{}, time.Time{}, false, nil
+	}
+	return rows[0].HighPrice, rows[0].Bucket.UTC(), true, nil
+}
+
+// PriceAtOrBefore returns the most recent price at or before ts for a pair on
+// the given side — the anchor for "price one year ago". It is a point lookup on
+// raw rwa_quote_prices over the (pair_id, side, ts) index. found=false when no
+// observation exists at/before ts (e.g. the pair is younger than the lookback).
+func (r *RWAPriceRepository) PriceAtOrBefore(
+	ctx context.Context, pairID int64, side string, ts time.Time,
+) (decimal.Decimal, time.Time, bool, error) {
+	var rows []struct {
+		Price decimal.Decimal `gorm:"column:price"`
+		TS    time.Time       `gorm:"column:ts"`
+	}
+	err := r.db.WithContext(ctx).Raw(
+		`SELECT price, ts
+		   FROM rwa_quote_prices
+		  WHERE pair_id = ? AND side = ? AND ts <= ?
+		  ORDER BY ts DESC
+		  LIMIT 1`,
+		pairID, side, ts.UTC()).Scan(&rows).Error
+	if err != nil {
+		return decimal.Decimal{}, time.Time{}, false, fmt.Errorf("query rwa price-at-or-before: %w", err)
+	}
+	if len(rows) == 0 {
+		return decimal.Decimal{}, time.Time{}, false, nil
+	}
+	return rows[0].Price, rows[0].TS.UTC(), true, nil
+}


### PR DESCRIPTION
Enriches the existing `GET /v1/rwa/:symbol/latest` response with all-time-high (price + date) and price-one-year-ago. No new endpoints - the pair is already resolved there and the multi-currency `?in=` path is reused, so the backend gets everything in one call.

**Changes**
- `rwa_price_repository.go` - `AllTimeHighLast` (argmax `high_price` over `rwa_quote_prices_1d`, `side='last'`) and `PriceAtOrBefore` (point lookup for the year-ago anchor).
- `handlers/rwa_prices.go` - `enrichLatest` adds `ath {price,date,…}` and `price_one_year_ago {price,…}` blocks, each converted at its own timestamp via the existing FX converter; the reader is optional (nil → blocks omitted, back-compat).
- Tests: native, `?in=` conversion, omitted blocks, not-found.